### PR TITLE
chore: update deployment workflow to include master branch and valida…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Cloudflare Pages
 
 on:
   push:
-    branches: ["dev"] # Triggers on dev branch
+    branches: ["dev", "master"] # dev = preview, master = production
 
 jobs:
   deploy:
@@ -34,13 +34,23 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
+      - name: Validate Cloudflare Pages config
+        env:
+          CF_PAGES_PROJECT_NAME: ${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}
+        run: |
+          if [ -z "$CF_PAGES_PROJECT_NAME" ]; then
+            echo "Missing Cloudflare Pages project name."
+            echo "Set CLOUDFLARE_PAGES_PROJECT_NAME in repository Variables (preferred) or Secrets."
+            exit 1
+          fi
+
       - name: Deploy to Cloudflare Pages
         id: cloudflare
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: "personal-website" # Update with your CF Pages project name
+          projectName: ${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}
           directory: "dist"
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.head_ref || github.ref_name }} # Deploys using branch name for preview URLs in CF
+          branch: ${{ github.head_ref || github.ref_name }} # master deploys production if set as Pages production branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      CLOUDFLARE_PAGES_PROJECT_NAME: ${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}
     environment:
-      name: dev
+      name: ${{ github.ref_name == 'master' && 'production' || 'dev' }}
       url: ${{ steps.cloudflare.outputs.url }}
     permissions:
       contents: read
@@ -36,7 +37,7 @@ jobs:
 
       - name: Validate Cloudflare Pages config
         env:
-          CF_PAGES_PROJECT_NAME: ${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}
+          CF_PAGES_PROJECT_NAME: ${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}
         run: |
           if [ -z "$CF_PAGES_PROJECT_NAME" ]; then
             echo "Missing Cloudflare Pages project name."
@@ -50,7 +51,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: ${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}
+          projectName: ${{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}
           directory: "dist"
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.head_ref || github.ref_name }} # master deploys production if set as Pages production branch
+          branch: ${{ github.head_ref || github.ref_name }} # master should match the Pages production branch setting


### PR DESCRIPTION
This pull request updates the Cloudflare Pages deployment workflow to support deployments from both the `dev` and `master` branches, and improves the configuration validation for the Cloudflare Pages project name. The main goal is to streamline deployments for both preview and production environments and to prevent misconfigurations.

**Workflow improvements:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L5-R5): The workflow now triggers on pushes to both `dev` (for preview) and `master` (for production) branches, instead of only `dev`.

**Configuration validation:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R37-R56): Added a step to validate that the Cloudflare Pages project name is set in either repository variables or secrets, failing early if missing.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R37-R56): Updated the `projectName` input for the Cloudflare Pages deploy action to use the repository variable or secret, rather than a hardcoded value.

**Deployment logic:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R37-R56): Clarified branch handling in deployment step comments, indicating that `master` deploys to production if set as the Pages production branch.