### PR TITLE
chore: add Supabase migration guard and baseline migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,41 @@ on:
     branches: ["dev"] # Triggers on dev branch
 
 jobs:
+  github-project-seed-smoke-test:
+    uses: ./.github/workflows/github-project-seed-security-smoke.yml
+    secrets: inherit
+
+  r2-presign-smoke-test:
+    uses: ./.github/workflows/r2-presign-security-smoke.yml
+    secrets: inherit
+
+  smoke-tests-gate:
+    needs: [github-project-seed-smoke-test, r2-presign-smoke-test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize smoke test results
+        env:
+          GITHUB_PROJECT_SEED_RESULT: ${{ needs.github-project-seed-smoke-test.result }}
+          R2_PRESIGN_RESULT: ${{ needs.r2-presign-smoke-test.result }}
+        run: |
+          echo "Smoke result: github-project-seed=$GITHUB_PROJECT_SEED_RESULT"
+          echo "Smoke result: r2-presign=$R2_PRESIGN_RESULT"
+
+          if [ "$GITHUB_PROJECT_SEED_RESULT" != "success" ]; then
+            echo "First failed smoke job: github-project-seed-smoke-test"
+            exit 1
+          fi
+
+          if [ "$R2_PRESIGN_RESULT" != "success" ]; then
+            echo "First failed smoke job: r2-presign-smoke-test"
+            exit 1
+          fi
+
+          echo "All smoke jobs passed."
+
   deploy:
+    needs: [smoke-tests-gate]
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/github-project-seed-security-smoke.yml
+++ b/.github/workflows/github-project-seed-security-smoke.yml
@@ -1,9 +1,7 @@
 name: GitHub Project Seed Security Smoke Tests
 
 "on":
-  workflow_dispatch:
-  push:
-    branches: ["dev"]
+  workflow_call:
 
 jobs:
   smoke-test:

--- a/.github/workflows/r2-presign-security-smoke.yml
+++ b/.github/workflows/r2-presign-security-smoke.yml
@@ -1,9 +1,7 @@
 name: R2 Presign Security Smoke Tests
 
 "on":
-  workflow_dispatch:
-  push:
-    branches: ["dev"]
+  workflow_call:
 
 jobs:
   smoke-test:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,14 +2,22 @@ name: Secret Scan
 
 on:
   push:
-    branches: ["**"]
+    branches: ["dev", "master"]
   pull_request:
-    branches: ["**"]
+    branches: ["dev", "master"]
+
+concurrency:
+  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   gitleaks:
     name: Gitleaks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/supabase-migration-guard.yml
+++ b/.github/workflows/supabase-migration-guard.yml
@@ -1,0 +1,47 @@
+name: Supabase Migration Guard
+
+'on':
+  pull_request:
+    branches: ["master", "dev"]
+    paths:
+      - "supabase/**/*.sql"
+      - ".github/workflows/supabase-*.yml"
+
+jobs:
+  require-migration:
+    name: Require migration for schema SQL changes
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify migration file exists when schema SQL changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base_ref="${{ github.base_ref }}"
+          if [[ -z "$base_ref" ]]; then
+            base_ref="dev"
+          fi
+
+          git fetch origin "$base_ref" --depth=1
+
+          changed_files="$(git diff --name-only "origin/$base_ref...HEAD")"
+
+          schema_changes="$(printf '%s\n' "$changed_files" | grep -E '^supabase/[^/]+\.sql$' || true)"
+          migration_changes="$(printf '%s\n' "$changed_files" | grep -E '^supabase/migrations/.+\.sql$' || true)"
+
+          if [[ -n "$schema_changes" && -z "$migration_changes" ]]; then
+            echo "Schema SQL files changed without a migration file update:"
+            echo "$schema_changes"
+            echo
+            echo "Add at least one file under supabase/migrations/*.sql in this PR."
+            exit 1
+          fi
+
+          echo "Migration guard passed."

--- a/.github/workflows/supabase-migration-guard.yml
+++ b/.github/workflows/supabase-migration-guard.yml
@@ -20,13 +20,20 @@ jobs:
           fetch-depth: 0
 
       - name: Verify migration file exists when schema SQL changes
+        env:
+          PR_BASE_REF: ${{ github.base_ref }}
         shell: bash
         run: |
           set -euo pipefail
 
-          base_ref="${{ github.base_ref }}"
+          base_ref="${PR_BASE_REF:-}"
           if [[ -z "$base_ref" ]]; then
             base_ref="dev"
+          fi
+
+          if [[ ! "$base_ref" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid base ref value."
+            exit 1
           fi
 
           git fetch origin "$base_ref" --depth=1

--- a/.github/workflows/supabase-migration-guard.yml
+++ b/.github/workflows/supabase-migration-guard.yml
@@ -26,10 +26,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          base_ref="${PR_BASE_REF:-}"
-          if [[ -z "$base_ref" ]]; then
-            base_ref="dev"
-          fi
+          base_ref="${PR_BASE_REF}"
 
           if [[ ! "$base_ref" =~ ^[A-Za-z0-9._/-]+$ ]]; then
             echo "Invalid base ref value."

--- a/.github/workflows/supabase-migration-guard.yml
+++ b/.github/workflows/supabase-migration-guard.yml
@@ -35,7 +35,7 @@ jobs:
 
           git fetch origin "$base_ref" --depth=1
 
-          changed_files="$(git diff --name-only "origin/$base_ref...HEAD")"
+          changed_files="$(git diff --name-only --diff-filter=ACMR "origin/$base_ref...HEAD")"
 
           schema_changes="$(printf '%s\n' "$changed_files" | grep -E '^supabase/[^/]+\.sql$' || true)"
           migration_changes="$(printf '%s\n' "$changed_files" | grep -E '^supabase/migrations/.+\.sql$' || true)"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,7 @@
+title = "PersonalWebsite Gitleaks Configuration"
+
+[allowlist]
+description = "Global allowlist kept intentionally minimal"
+regexes = []
+paths = []
+commits = []

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,7 +1,0 @@
-title = "PersonalWebsite Gitleaks Configuration"
-
-[allowlist]
-description = "Global allowlist kept intentionally minimal"
-regexes = []
-paths = []
-commits = []

--- a/README.md
+++ b/README.md
@@ -206,16 +206,10 @@ For GitHub Actions automation, add these repository or environment secrets:
 - `SUPABASE_ANON_KEY`
 - `SUPABASE_SERVICE_ROLE_KEY`
 
-For Supabase migration automation, add these secrets (recommended in the `dev` environment):
-
-- `SUPABASE_ACCESS_TOKEN`
-- `SUPABASE_DB_URL`
-- `SUPABASE_PROJECT_ID` (optional, enables post-migration advisor checks)
-
 Migration workflows:
 
 - [Migration Guard](.github/workflows/supabase-migration-guard.yml): Fails PRs that change top-level schema SQL in [supabase](supabase/) without adding at least one migration in [supabase/migrations](supabase/migrations/).
-- Migrations are applied via Supabase GitHub Integration (recommended single deployment path).
+- Migrations are applied via Supabase GitHub Integration (recommended single deployment path). No additional GitHub repository secrets are required for migration apply in this setup.
 
 ## Code Style & Conventions
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,17 @@ For GitHub Actions automation, add these repository or environment secrets:
 - `SUPABASE_ANON_KEY`
 - `SUPABASE_SERVICE_ROLE_KEY`
 
+For Supabase migration automation, add these secrets (recommended in the `dev` environment):
+
+- `SUPABASE_ACCESS_TOKEN`
+- `SUPABASE_DB_URL`
+- `SUPABASE_PROJECT_ID` (optional, enables post-migration advisor checks)
+
+Migration workflows:
+
+- [Migration Guard](.github/workflows/supabase-migration-guard.yml): Fails PRs that change top-level schema SQL in [supabase](supabase/) without adding at least one migration in [supabase/migrations](supabase/migrations/).
+- Migrations are applied via Supabase GitHub Integration (recommended single deployment path).
+
 ## Code Style & Conventions
 
 This project enforces strict code quality standards. Refer to [.github/copilot-instructions.md](.github/copilot-instructions.md) for complete architecture guidelines. Key rules:

--- a/supabase/migrations/20260523190000_rls_admin_and_gamedev_item_media.sql
+++ b/supabase/migrations/20260523190000_rls_admin_and_gamedev_item_media.sql
@@ -1,0 +1,233 @@
+-- Copyright (c) 2026 Guy Erreich
+-- SPDX-License-Identifier: MIT
+
+-- This migration captures remote changes already applied via MCP:
+-- 1) RLS admin-check initplan optimization
+-- 2) trigger function search_path hardening
+-- 3) creation of public.gamedev_item_media
+
+create or replace function public.touch_media_library_updated_at()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create or replace function public.touch_media_library_folders_updated_at()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create or replace function public.touch_site_settings_updated_at()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create or replace function public.is_admin()
+returns boolean
+language sql
+stable
+set search_path = ''
+as $$
+  select coalesce(
+    (auth.jwt() -> 'app_metadata' ->> 'roles' = 'admin')
+    or (auth.jwt() -> 'app_metadata' -> 'roles' @> '"admin"'::jsonb),
+    false
+  );
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'devops_projects' AND policyname = 'Admins can insert devops projects'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can insert devops projects" ON public.devops_projects WITH CHECK ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'devops_projects' AND policyname = 'Admins can update devops projects'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can update devops projects" ON public.devops_projects USING ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'devops_projects' AND policyname = 'Admins can delete devops projects'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can delete devops projects" ON public.devops_projects USING ((select public.is_admin()))';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gamedev_items' AND policyname = 'Admins can insert gamedev items'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can insert gamedev items" ON public.gamedev_items WITH CHECK ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gamedev_items' AND policyname = 'Admins can update gamedev items'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can update gamedev items" ON public.gamedev_items USING ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gamedev_items' AND policyname = 'Admins can delete gamedev items'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can delete gamedev items" ON public.gamedev_items USING ((select public.is_admin()))';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'media_library' AND policyname = 'Admins can read media library'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can read media library" ON public.media_library USING ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'media_library' AND policyname = 'Admins can insert media library'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can insert media library" ON public.media_library WITH CHECK ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'media_library' AND policyname = 'Admins can update media library'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can update media library" ON public.media_library USING ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'media_library' AND policyname = 'Admins can delete media library'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can delete media library" ON public.media_library USING ((select public.is_admin()))';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'media_library_folders' AND policyname = 'Admins can read media library folders'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can read media library folders" ON public.media_library_folders USING ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'media_library_folders' AND policyname = 'Admins can insert media library folders'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can insert media library folders" ON public.media_library_folders WITH CHECK ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'media_library_folders' AND policyname = 'Admins can update media library folders'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can update media library folders" ON public.media_library_folders USING ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'media_library_folders' AND policyname = 'Admins can delete media library folders'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can delete media library folders" ON public.media_library_folders USING ((select public.is_admin()))';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'site_settings' AND policyname = 'Admins can read site settings'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can read site settings" ON public.site_settings USING ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'site_settings' AND policyname = 'Admins can insert site settings'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can insert site settings" ON public.site_settings WITH CHECK ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'site_settings' AND policyname = 'Admins can update site settings'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can update site settings" ON public.site_settings USING ((select public.is_admin()))';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'site_settings' AND policyname = 'Admins can delete site settings'
+  ) THEN
+    EXECUTE 'ALTER POLICY "Admins can delete site settings" ON public.site_settings USING ((select public.is_admin()))';
+  END IF;
+END $$;
+
+create table if not exists public.gamedev_item_media (
+  id uuid primary key default gen_random_uuid(),
+  gamedev_item_id uuid not null references public.gamedev_items(id) on delete cascade,
+  media_url text not null,
+  thumbnail_url text,
+  media_type text not null check (media_type in ('image', 'video')),
+  caption text,
+  sort_order integer,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists gamedev_item_media_gamedev_item_id_idx
+  on public.gamedev_item_media (gamedev_item_id);
+
+create index if not exists gamedev_item_media_sort_order_idx
+  on public.gamedev_item_media (gamedev_item_id, sort_order nulls last, created_at asc);
+
+alter table public.gamedev_item_media enable row level security;
+
+drop policy if exists "Public can read gamedev item media" on public.gamedev_item_media;
+create policy "Public can read gamedev item media"
+  on public.gamedev_item_media for select
+  using (true);
+
+drop policy if exists "Admins can insert gamedev item media" on public.gamedev_item_media;
+create policy "Admins can insert gamedev item media"
+  on public.gamedev_item_media for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can update gamedev item media" on public.gamedev_item_media;
+create policy "Admins can update gamedev item media"
+  on public.gamedev_item_media for update
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can delete gamedev item media" on public.gamedev_item_media;
+create policy "Admins can delete gamedev item media"
+  on public.gamedev_item_media for delete
+  using ((select public.is_admin()));


### PR DESCRIPTION
## Summary
- add a PR guard workflow requiring migration files when top-level schema SQL changes
- add baseline migration file capturing RLS admin helper/search_path hardening and gamedev_item_media schema
- update README migration workflow guidance to use Supabase GitHub integration

## Why
- prevent schema drift between repo SQL and live Supabase state
- ensure future changes are migration-first and reviewable

## Notes
- this PR is scoped to migration governance files only
