### PR TITLE
Improve R2 browser upload diagnostics and infra tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,19 @@
+# --- Browser (Vite) ---
+# Vite ONLY exposes VITE_* to import.meta.env — required for the React app.
+# URL + anon key are public client config (protected by RLS, not secret).
 VITE_SUPABASE_URL=https://your-project-id.supabase.co
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
-VITE_CLOUDFLARE_ACCOUNT_ID=your_cloudflare_account_id
-VITE_R2_ACCESS_KEY_ID=your_r2_access_key_id
-VITE_R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
-VITE_R2_BUCKET_NAME=your_r2_bucket_name
-VITE_R2_PUBLIC_URL=https://your-account-id.r2.cloudflarestorage.com
+# --- Node scripts only (smoke tests, optional) ---
+# Same values as above, or omit and scripts read VITE_SUPABASE_* automatically.
+# SUPABASE_URL=https://your-project-id.supabase.co
+# SUPABASE_ANON_KEY=your_supabase_anon_key
+# SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+
+# --- R2 infra scripts only (never VITE_ — never bundled) ---
+# Names match Supabase r2-presign secrets. Production uploads use Supabase secrets.
+R2_ACCOUNT_ID=your_cloudflare_account_id
+R2_ACCESS_KEY_ID=your_r2_access_key_id
+R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
+R2_BUCKET_NAME=your_r2_bucket_name
+R2_PUBLIC_URL=https://pub-your-bucket-id.r2.dev

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ dist-ssr
 *.sln
 *.sw?
 .env
+scripts/infra/r2-cors.json
 supabase/.temp/

--- a/README.md
+++ b/README.md
@@ -146,14 +146,33 @@ export const isMidTierOrConstrainedDevice = (): boolean => {
 
 ### Environment Variables
 
-Create a `.env.local` file at the root with the following variables:
+Create a `.env.local` file at the root (gitignored). Copy from [`.env.example`](.env.example).
+
+| Prefix | Used by | Notes |
+|--------|---------|-------|
+| `VITE_SUPABASE_*` | React app (browser) | **Required** — Vite only exposes `VITE_*` to `import.meta.env` |
+| `SUPABASE_*` | Node smoke tests (optional) | Same values; scripts fall back to `VITE_SUPABASE_*` if unset |
+| `R2_*` | `npm run infra:*` only | Secrets — **never** use `VITE_` for R2 keys |
+
+**Browser:**
 
 ```env
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 ```
 
-R2 credentials are **not** stored in the browser bundle. They live as Supabase secrets and are used exclusively inside the `r2-presign` edge function. Set them once via the Supabase CLI:
+**Optional local tooling** (infra + smoke tests from `.env.local`):
+
+```env
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=
+R2_PUBLIC_URL=
+SUPABASE_SERVICE_ROLE_KEY=   # smoke tests only — never VITE_ prefix
+```
+
+Production **upload auth** uses Supabase secrets on the edge function, not `.env.local`. Set via CLI:
 
 ```bash
 supabase secrets set R2_ACCOUNT_ID=<your-cloudflare-account-id>
@@ -162,6 +181,7 @@ supabase secrets set R2_SECRET_ACCESS_KEY=<your-r2-secret-key>
 supabase secrets set R2_BUCKET_NAME=<your-bucket-name>
 supabase secrets set R2_PUBLIC_URL=<your-r2-public-url>
 supabase secrets set ALLOWED_ORIGINS=<comma-separated-allowed-origins>
+supabase secrets set LOG_LEVEL=info   # optional: debug | info | warn | error
 ```
 
 Admin authorization for `r2-presign` is based on Supabase Auth metadata (`app_metadata.roles` contains `"admin"`), not an email allowlist secret.
@@ -171,6 +191,44 @@ Deploy the edge function after setting secrets:
 ```bash
 supabase functions deploy r2-presign
 ```
+
+**R2 bucket CORS (required for browser uploads):** `ALLOWED_ORIGINS` only covers the presign POST to Supabase. The browser also PUTs files directly to `*.r2.cloudflarestorage.com`, which needs a separate CORS policy on the R2 bucket.
+
+1. Copy and edit the example (use the **same origins** as `ALLOWED_ORIGINS`):
+
+```bash
+cp scripts/infra/r2-cors.example.json scripts/infra/r2-cors.json
+# edit scripts/infra/r2-cors.json — replace placeholder origins with your site URL(s)
+```
+
+2. Apply with your R2 admin credentials (from `.env.local` or inline):
+
+```bash
+npm run infra:apply-r2-cors
+```
+
+Or pass origins via env (no file):
+
+```bash
+R2_CORS_ORIGINS="https://your-site.pages.dev" npm run infra:apply-r2-cors
+```
+
+Alternatively, set CORS in Cloudflare Dashboard → R2 → your bucket → Settings → CORS policy.
+
+**Important R2 CORS gotchas:**
+- CORS must be on the **same bucket** as your `R2_BUCKET_NAME` Supabase secret (not the public custom domain).
+- `AllowedOrigins` must match `window.location.origin` exactly (no trailing slash).
+- `AllowedHeaders` must include `Content-Type` (same HTTP header the browser sends on PUT — see `r2client.ts`). If uploads still fail, try lowercase `content-type` in the dashboard; R2 CORS matching can be picky even though HTTP header names are case-insensitive.
+- Dashboard JSON is a **top-level array** (not a `"rules"` wrapper).
+- Changes can take ~30 seconds to propagate.
+
+Verify current bucket CORS:
+
+```bash
+npm run infra:get-r2-cors
+```
+
+After presign succeeds but upload fails with `Failed to fetch`, check DevTools Network for a failed `OPTIONS` or `PUT` to `r2.cloudflarestorage.com` — that indicates missing or misconfigured R2 bucket CORS.
 
 ### Install & Run
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "framer-motion": "^12.34.3",
         "gsap": "^3.14.2",
+        "headroom-ai": "^0.22.4",
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.575.0",
         "mermaid": "^11.14.0",
@@ -36,6 +37,7 @@
         "tsparticles": "^3.9.1"
       },
       "devDependencies": {
+        "@aws-sdk/client-s3": "^3.1026.0",
         "@biomejs/biome": "^2.4.10",
         "@tailwindcss/vite": "^4.2.0",
         "@types/js-cookie": "^3.0.6",
@@ -67,6 +69,697 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.7.tgz",
+      "integrity": "sha512-qh0fG/RtrFztst4+vn1HZehAvAhr5Jlq/WMP7e5KvvfF16oNVBc9CDNVdxdm19vzOY2x0qiDMFCRjhxQAusGWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1073.0.tgz",
+      "integrity": "sha512-/Dvhrff0I4D2YUWSdm8uLKa1bfXdw9BMRDUME6ZeoTrrdQKQDeo2scLDjdpC5X2YdvTc/ZnUCR2HAvD7qXvS1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.32",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.53",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
+      "integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.30",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.48.tgz",
+      "integrity": "sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.50.tgz",
+      "integrity": "sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.55.tgz",
+      "integrity": "sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-env": "^3.972.48",
+        "@aws-sdk/credential-provider-http": "^3.972.50",
+        "@aws-sdk/credential-provider-login": "^3.972.54",
+        "@aws-sdk/credential-provider-process": "^3.972.48",
+        "@aws-sdk/credential-provider-sso": "^3.972.54",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.54.tgz",
+      "integrity": "sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.57.tgz",
+      "integrity": "sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.48",
+        "@aws-sdk/credential-provider-http": "^3.972.50",
+        "@aws-sdk/credential-provider-ini": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.48",
+        "@aws-sdk/credential-provider-sso": "^3.972.54",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.48.tgz",
+      "integrity": "sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.54.tgz",
+      "integrity": "sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/token-providers": "3.1071.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.54.tgz",
+      "integrity": "sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.32.tgz",
+      "integrity": "sha512-KhuzFMzUbb3oEj43CdPDbEJ/RG/RkErkmXk3J/LE8OPFNvkCn8PYPMpjOLgzAzvxBacsSyytdWf+R50q0alJ4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.53.tgz",
+      "integrity": "sha512-keWp6Z5cEIJzPwoCf/WRm0ceAeephPDDivhRsK/xXs2ZYXyypJ2/DL9G1IR0bz/s+iZC0EgzmFV4r7rlvLlxQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+      "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1071.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1071.0.tgz",
+      "integrity": "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
+      "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -625,6 +1318,19 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@react-three/drei": {
       "version": "10.7.7",
       "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
@@ -987,6 +1693,135 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -2806,6 +3641,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2908,6 +3756,13 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -4125,6 +4980,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fault": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
@@ -4470,36 +5364,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/headroom-ai": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/headroom-ai/-/headroom-ai-0.22.4.tgz",
-      "integrity": "sha512-9a0rgB/jsWe8gs/ggyUwe6E8DYwKAuBvlUml2ApwlUjb5EfJ611X6X+WG0SiXw3nO6sdyV1/+Ah5uw9P7ecnjw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@ai-sdk/provider": ">=1.0.0",
-        "@anthropic-ai/sdk": ">=0.30.0",
-        "ai": ">=6.0.0",
-        "openai": ">=4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@ai-sdk/provider": {
-          "optional": true
-        },
-        "@anthropic-ai/sdk": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
       }
     },
     "node_modules/highlight.js": {
@@ -6337,6 +7201,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.0.tgz",
+      "integrity": "sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6936,6 +7816,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/style-to-js": {
@@ -7641,6 +8537,29 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "framer-motion": "^12.34.3",
         "gsap": "^3.14.2",
-        "headroom-ai": "^0.22.4",
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.575.0",
         "mermaid": "^11.14.0",
@@ -526,240 +525,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1308,16 +1073,6 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
     "node_modules/@nodable/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
@@ -1330,6 +1085,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@react-three/drei": {
       "version": "10.7.7",
@@ -8553,13 +8318,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "framer-motion": "^12.34.3",
     "gsap": "^3.14.2",
-    "headroom-ai": "^0.22.4",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.575.0",
     "mermaid": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint . && biome check .",
     "security:test:r2-presign": "node scripts/security/r2-presign-smoke.mjs",
     "security:test:github-seed": "node scripts/security/github-project-seed-smoke.mjs",
+    "infra:apply-r2-cors": "node scripts/infra/apply-r2-cors.mjs",
+    "infra:get-r2-cors": "node scripts/infra/get-r2-cors.mjs",
     "format": "biome format --write .",
     "preview": "vite preview"
   },
@@ -25,6 +27,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "framer-motion": "^12.34.3",
     "gsap": "^3.14.2",
+    "headroom-ai": "^0.22.4",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.575.0",
     "mermaid": "^11.14.0",
@@ -41,6 +44,7 @@
     "tsparticles": "^3.9.1"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.1026.0",
     "@biomejs/biome": "^2.4.10",
     "@tailwindcss/vite": "^4.2.0",
     "@types/js-cookie": "^3.0.6",

--- a/scripts/infra/apply-r2-cors.mjs
+++ b/scripts/infra/apply-r2-cors.mjs
@@ -1,0 +1,81 @@
+/*
+ * Apply CORS rules to a Cloudflare R2 bucket (required for browser PUT uploads).
+ *
+ * Required credentials in .env.local (see .env.example):
+ *   R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME
+ *
+ * Origins (one of):
+ *   R2_CORS_ORIGINS — comma-separated list (same format as ALLOWED_ORIGINS)
+ *   R2_CORS_FILE    — path to JSON file (default: scripts/infra/r2-cors.json)
+ *
+ * Usage:
+ *   cp scripts/infra/r2-cors.example.json scripts/infra/r2-cors.json
+ *   # edit r2-cors.json with your site origin(s)
+ *   R2_ACCOUNT_ID=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... R2_BUCKET_NAME=... \
+ *     npm run infra:apply-r2-cors
+ *
+ * Or with env origins only:
+ *   R2_CORS_ORIGINS="https://your-site.pages.dev" npm run infra:apply-r2-cors
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { PutBucketCorsCommand, S3Client } from "@aws-sdk/client-s3";
+import { requireR2Env } from "./load-r2-env.mjs";
+
+const { accountId, accessKeyId, secretAccessKey, bucket } = requireR2Env();
+const corsOriginsEnv = process.env.R2_CORS_ORIGINS;
+const corsFile = process.env.R2_CORS_FILE ?? "scripts/infra/r2-cors.json";
+
+const loadCorsRules = () => {
+  if (typeof corsOriginsEnv === "string" && corsOriginsEnv.trim().length > 0) {
+    const origins = corsOriginsEnv
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean);
+
+    if (origins.length === 0) {
+      throw new Error("R2_CORS_ORIGINS is empty after parsing.");
+    }
+
+    return [
+      {
+        AllowedOrigins: origins,
+        AllowedMethods: ["PUT", "GET", "HEAD"],
+        AllowedHeaders: ["Content-Type", "Content-Length"],
+        ExposeHeaders: ["ETag"],
+        MaxAgeSeconds: 3600,
+      },
+    ];
+  }
+
+  const filePath = resolve(process.cwd(), corsFile);
+  const raw = readFileSync(filePath, "utf8");
+  const parsed = JSON.parse(raw);
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(`${corsFile} must be a non-empty JSON array of CORS rules.`);
+  }
+
+  return parsed;
+};
+
+const corsRules = loadCorsRules();
+
+const s3 = new S3Client({
+  region: "auto",
+  endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId, secretAccessKey },
+});
+
+console.warn(`Applying R2 bucket CORS to "${bucket}"...`);
+console.warn(JSON.stringify(corsRules, null, 2));
+
+await s3.send(
+  new PutBucketCorsCommand({
+    Bucket: bucket,
+    CORSConfiguration: { CORSRules: corsRules },
+  }),
+);
+
+console.warn("R2 bucket CORS applied successfully.");

--- a/scripts/infra/get-r2-cors.mjs
+++ b/scripts/infra/get-r2-cors.mjs
@@ -1,0 +1,32 @@
+/*
+ * Print the current CORS policy on an R2 bucket (for debugging upload failures).
+ *
+ * Reads credentials from .env.local / .env (R2_* names — see .env.example).
+ */
+
+import { GetBucketCorsCommand, S3Client } from "@aws-sdk/client-s3";
+import { requireR2Env } from "./load-r2-env.mjs";
+
+const { accountId, accessKeyId, secretAccessKey, bucket } = requireR2Env();
+
+const s3 = new S3Client({
+  region: "auto",
+  endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId, secretAccessKey },
+});
+
+try {
+  const result = await s3.send(new GetBucketCorsCommand({ Bucket: bucket }));
+  console.warn(`CORS policy for bucket "${bucket}":`);
+  console.warn(JSON.stringify(result.CORSRules ?? [], null, 2));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("NoSuchCORSConfiguration") || message.includes("not found")) {
+    console.error(
+      `No CORS policy on bucket "${bucket}". Browser uploads will fail until CORS is applied.`,
+    );
+    process.exit(1);
+  }
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/infra/load-env.mjs
+++ b/scripts/infra/load-env.mjs
@@ -1,0 +1,64 @@
+/*
+ * Shared .env file parsing for Node infra/security scripts.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export const parseEnvFile = (filePath) => {
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    const values = {};
+
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      const separatorIndex = trimmed.indexOf("=");
+      if (separatorIndex <= 0) continue;
+
+      const key = trimmed.slice(0, separatorIndex).trim();
+      let value = trimmed.slice(separatorIndex + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+
+      values[key] = value;
+    }
+
+    return values;
+  } catch {
+    return {};
+  }
+};
+
+export const mergeEnvFiles = () => {
+  const root = process.cwd();
+  return {
+    ...parseEnvFile(resolve(root, ".env")),
+    ...parseEnvFile(resolve(root, ".env.local")),
+  };
+};
+
+/**
+ * @param {Record<string, string>} fileEnv
+ * @param {{ onKeyRead?: (key: string) => void }} [options]
+ */
+export const createEnvReader = (fileEnv, { onKeyRead } = {}) => {
+  return (keys) => {
+    for (const key of keys) {
+      if (process.env[key]) {
+        onKeyRead?.(key);
+        return process.env[key];
+      }
+      if (fileEnv[key]) {
+        onKeyRead?.(key);
+        return fileEnv[key];
+      }
+    }
+    return undefined;
+  };
+};

--- a/scripts/infra/load-r2-env.mjs
+++ b/scripts/infra/load-r2-env.mjs
@@ -7,8 +7,7 @@
  * Legacy VITE_R2_* / VITE_CLOUDFLARE_ACCOUNT_ID names are still read with a warning.
  */
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { createEnvReader, mergeEnvFiles } from "./load-env.mjs";
 
 const ENV_ALIASES = {
   R2_ACCOUNT_ID: ["R2_ACCOUNT_ID", "VITE_CLOUDFLARE_ACCOUNT_ID"],
@@ -25,46 +24,6 @@ const LEGACY_KEYS = new Set([
   "VITE_R2_PUBLIC_URL",
 ]);
 
-const parseEnvFile = (filePath) => {
-  try {
-    const raw = readFileSync(filePath, "utf8");
-    const values = {};
-
-    for (const line of raw.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
-
-      const separatorIndex = trimmed.indexOf("=");
-      if (separatorIndex <= 0) continue;
-
-      const key = trimmed.slice(0, separatorIndex).trim();
-      let value = trimmed.slice(separatorIndex + 1).trim();
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1);
-      }
-
-      values[key] = value;
-    }
-
-    return values;
-  } catch {
-    return {};
-  }
-};
-
-const mergeEnvFiles = () => {
-  const root = process.cwd();
-  return {
-    ...parseEnvFile(resolve(root, ".env")),
-    ...parseEnvFile(resolve(root, ".env.local")),
-  };
-};
-
-const fileEnv = mergeEnvFiles();
-
 let legacyWarningShown = false;
 
 const warnLegacyEnvNames = (key) => {
@@ -75,19 +34,7 @@ const warnLegacyEnvNames = (key) => {
   );
 };
 
-const readValue = (keys) => {
-  for (const key of keys) {
-    if (process.env[key]) {
-      warnLegacyEnvNames(key);
-      return process.env[key];
-    }
-    if (fileEnv[key]) {
-      warnLegacyEnvNames(key);
-      return fileEnv[key];
-    }
-  }
-  return undefined;
-};
+const readValue = createEnvReader(mergeEnvFiles(), { onKeyRead: warnLegacyEnvNames });
 
 export const loadR2Env = () => ({
   accountId: readValue(ENV_ALIASES.R2_ACCOUNT_ID),

--- a/scripts/infra/load-r2-env.mjs
+++ b/scripts/infra/load-r2-env.mjs
@@ -1,0 +1,117 @@
+/*
+ * Resolve R2 credentials from process env or project .env files.
+ *
+ * Canonical names (match Supabase r2-presign secrets):
+ *   R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME
+ *
+ * Legacy VITE_R2_* / VITE_CLOUDFLARE_ACCOUNT_ID names are still read with a warning.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ENV_ALIASES = {
+  R2_ACCOUNT_ID: ["R2_ACCOUNT_ID", "VITE_CLOUDFLARE_ACCOUNT_ID"],
+  R2_ACCESS_KEY_ID: ["R2_ACCESS_KEY_ID", "VITE_R2_ACCESS_KEY_ID"],
+  R2_SECRET_ACCESS_KEY: ["R2_SECRET_ACCESS_KEY", "VITE_R2_SECRET_ACCESS_KEY"],
+  R2_BUCKET_NAME: ["R2_BUCKET_NAME", "VITE_R2_BUCKET_NAME"],
+};
+
+const LEGACY_KEYS = new Set([
+  "VITE_CLOUDFLARE_ACCOUNT_ID",
+  "VITE_R2_ACCESS_KEY_ID",
+  "VITE_R2_SECRET_ACCESS_KEY",
+  "VITE_R2_BUCKET_NAME",
+  "VITE_R2_PUBLIC_URL",
+]);
+
+const parseEnvFile = (filePath) => {
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    const values = {};
+
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      const separatorIndex = trimmed.indexOf("=");
+      if (separatorIndex <= 0) continue;
+
+      const key = trimmed.slice(0, separatorIndex).trim();
+      let value = trimmed.slice(separatorIndex + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+
+      values[key] = value;
+    }
+
+    return values;
+  } catch {
+    return {};
+  }
+};
+
+const mergeEnvFiles = () => {
+  const root = process.cwd();
+  return {
+    ...parseEnvFile(resolve(root, ".env")),
+    ...parseEnvFile(resolve(root, ".env.local")),
+  };
+};
+
+const fileEnv = mergeEnvFiles();
+
+let legacyWarningShown = false;
+
+const warnLegacyEnvNames = (key) => {
+  if (legacyWarningShown || !LEGACY_KEYS.has(key)) return;
+  legacyWarningShown = true;
+  console.warn(
+    "Using legacy VITE_R2_* / VITE_CLOUDFLARE_* env names. Rename to R2_* (see .env.example). VITE_ secrets must not be used for R2 credentials.",
+  );
+};
+
+const readValue = (keys) => {
+  for (const key of keys) {
+    if (process.env[key]) {
+      warnLegacyEnvNames(key);
+      return process.env[key];
+    }
+    if (fileEnv[key]) {
+      warnLegacyEnvNames(key);
+      return fileEnv[key];
+    }
+  }
+  return undefined;
+};
+
+export const loadR2Env = () => ({
+  accountId: readValue(ENV_ALIASES.R2_ACCOUNT_ID),
+  accessKeyId: readValue(ENV_ALIASES.R2_ACCESS_KEY_ID),
+  secretAccessKey: readValue(ENV_ALIASES.R2_SECRET_ACCESS_KEY),
+  bucket: readValue(ENV_ALIASES.R2_BUCKET_NAME),
+});
+
+export const requireR2Env = () => {
+  const env = loadR2Env();
+  const missing = Object.entries({
+    R2_ACCOUNT_ID: env.accountId,
+    R2_ACCESS_KEY_ID: env.accessKeyId,
+    R2_SECRET_ACCESS_KEY: env.secretAccessKey,
+    R2_BUCKET_NAME: env.bucket,
+  })
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    console.error(`Missing required R2 env vars: ${missing.join(", ")}`);
+    console.error("Add them to .env.local — see .env.example (R2_* section, not VITE_*).");
+    process.exit(1);
+  }
+
+  return env;
+};

--- a/scripts/infra/load-supabase-env.mjs
+++ b/scripts/infra/load-supabase-env.mjs
@@ -1,0 +1,89 @@
+/*
+ * Resolve Supabase credentials from process env or project .env files.
+ *
+ * Browser app uses VITE_SUPABASE_* (Vite only exposes VITE_ to import.meta.env).
+ * Node scripts prefer SUPABASE_* but fall back to VITE_SUPABASE_* from .env.local.
+ *
+ * Never use VITE_ prefix for SUPABASE_SERVICE_ROLE_KEY.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ENV_ALIASES = {
+  SUPABASE_URL: ["SUPABASE_URL", "VITE_SUPABASE_URL"],
+  SUPABASE_ANON_KEY: ["SUPABASE_ANON_KEY", "VITE_SUPABASE_ANON_KEY"],
+  SUPABASE_SERVICE_ROLE_KEY: ["SUPABASE_SERVICE_ROLE_KEY"],
+};
+
+const parseEnvFile = (filePath) => {
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    const values = {};
+
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      const separatorIndex = trimmed.indexOf("=");
+      if (separatorIndex <= 0) continue;
+
+      const key = trimmed.slice(0, separatorIndex).trim();
+      let value = trimmed.slice(separatorIndex + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+
+      values[key] = value;
+    }
+
+    return values;
+  } catch {
+    return {};
+  }
+};
+
+const fileEnv = {
+  ...parseEnvFile(resolve(process.cwd(), ".env")),
+  ...parseEnvFile(resolve(process.cwd(), ".env.local")),
+};
+
+const readValue = (keys) => {
+  for (const key of keys) {
+    if (process.env[key]) return process.env[key];
+    if (fileEnv[key]) return fileEnv[key];
+  }
+  return undefined;
+};
+
+export const loadSupabaseEnv = () => ({
+  supabaseUrl: readValue(ENV_ALIASES.SUPABASE_URL),
+  supabaseAnonKey: readValue(ENV_ALIASES.SUPABASE_ANON_KEY),
+  supabaseServiceRoleKey: readValue(ENV_ALIASES.SUPABASE_SERVICE_ROLE_KEY),
+});
+
+export const requireSupabaseEnv = ({ requireServiceRole = false } = {}) => {
+  const env = loadSupabaseEnv();
+  const required = {
+    SUPABASE_URL: env.supabaseUrl,
+    SUPABASE_ANON_KEY: env.supabaseAnonKey,
+    ...(requireServiceRole ? { SUPABASE_SERVICE_ROLE_KEY: env.supabaseServiceRoleKey } : {}),
+  };
+
+  const missing = Object.entries(required)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    console.error(`Missing required Supabase env vars: ${missing.join(", ")}`);
+    console.error(
+      "Set VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY in .env.local (browser + scripts), or SUPABASE_* for Node-only.",
+    );
+    process.exit(1);
+  }
+
+  return env;
+};

--- a/scripts/infra/load-supabase-env.mjs
+++ b/scripts/infra/load-supabase-env.mjs
@@ -7,8 +7,7 @@
  * Never use VITE_ prefix for SUPABASE_SERVICE_ROLE_KEY.
  */
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { createEnvReader, mergeEnvFiles } from "./load-env.mjs";
 
 const ENV_ALIASES = {
   SUPABASE_URL: ["SUPABASE_URL", "VITE_SUPABASE_URL"],
@@ -16,48 +15,7 @@ const ENV_ALIASES = {
   SUPABASE_SERVICE_ROLE_KEY: ["SUPABASE_SERVICE_ROLE_KEY"],
 };
 
-const parseEnvFile = (filePath) => {
-  try {
-    const raw = readFileSync(filePath, "utf8");
-    const values = {};
-
-    for (const line of raw.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
-
-      const separatorIndex = trimmed.indexOf("=");
-      if (separatorIndex <= 0) continue;
-
-      const key = trimmed.slice(0, separatorIndex).trim();
-      let value = trimmed.slice(separatorIndex + 1).trim();
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1);
-      }
-
-      values[key] = value;
-    }
-
-    return values;
-  } catch {
-    return {};
-  }
-};
-
-const fileEnv = {
-  ...parseEnvFile(resolve(process.cwd(), ".env")),
-  ...parseEnvFile(resolve(process.cwd(), ".env.local")),
-};
-
-const readValue = (keys) => {
-  for (const key of keys) {
-    if (process.env[key]) return process.env[key];
-    if (fileEnv[key]) return fileEnv[key];
-  }
-  return undefined;
-};
+const readValue = createEnvReader(mergeEnvFiles());
 
 export const loadSupabaseEnv = () => ({
   supabaseUrl: readValue(ENV_ALIASES.SUPABASE_URL),

--- a/scripts/infra/r2-cors.example.json
+++ b/scripts/infra/r2-cors.example.json
@@ -1,0 +1,14 @@
+[
+  {
+    "AllowedOrigins": [
+      "https://your-project.pages.dev",
+      "https://yourdomain.com",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173"
+    ],
+    "AllowedMethods": ["PUT", "GET", "HEAD"],
+    "AllowedHeaders": ["Content-Type", "Content-Length"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3600
+  }
+]

--- a/scripts/security/github-project-seed-smoke.mjs
+++ b/scripts/security/github-project-seed-smoke.mjs
@@ -19,8 +19,11 @@ import { requireSupabaseEnv } from "../infra/load-supabase-env.mjs";
 const GITHUB_SEED_URL = process.env.GITHUB_SEED_URL;
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN;
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS;
-const { supabaseUrl: SUPABASE_URL, supabaseAnonKey: SUPABASE_ANON_KEY, supabaseServiceRoleKey: SUPABASE_SERVICE_ROLE_KEY } =
-  requireSupabaseEnv({ requireServiceRole: true });
+const {
+  supabaseUrl: SUPABASE_URL,
+  supabaseAnonKey: SUPABASE_ANON_KEY,
+  supabaseServiceRoleKey: SUPABASE_SERVICE_ROLE_KEY,
+} = requireSupabaseEnv({ requireServiceRole: true });
 const GITHUB_SEED_TEST_REPO_URL =
   process.env.GITHUB_SEED_TEST_REPO_URL ?? "https://github.com/octocat/Hello-World";
 

--- a/scripts/security/github-project-seed-smoke.mjs
+++ b/scripts/security/github-project-seed-smoke.mjs
@@ -14,21 +14,18 @@
 
 import { randomUUID } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
+import { requireSupabaseEnv } from "../infra/load-supabase-env.mjs";
 
 const GITHUB_SEED_URL = process.env.GITHUB_SEED_URL;
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN;
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS;
-const SUPABASE_URL = process.env.SUPABASE_URL;
-const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const { supabaseUrl: SUPABASE_URL, supabaseAnonKey: SUPABASE_ANON_KEY, supabaseServiceRoleKey: SUPABASE_SERVICE_ROLE_KEY } =
+  requireSupabaseEnv({ requireServiceRole: true });
 const GITHUB_SEED_TEST_REPO_URL =
   process.env.GITHUB_SEED_TEST_REPO_URL ?? "https://github.com/octocat/Hello-World";
 
 const required = {
   GITHUB_SEED_URL,
-  SUPABASE_URL,
-  SUPABASE_ANON_KEY,
-  SUPABASE_SERVICE_ROLE_KEY,
 };
 
 const missing = Object.entries(required)

--- a/scripts/security/r2-presign-smoke.mjs
+++ b/scripts/security/r2-presign-smoke.mjs
@@ -16,8 +16,11 @@ import { requireSupabaseEnv } from "../infra/load-supabase-env.mjs";
 const PRESIGN_URL = process.env.PRESIGN_URL;
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN;
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS;
-const { supabaseUrl: SUPABASE_URL, supabaseAnonKey: SUPABASE_ANON_KEY, supabaseServiceRoleKey: SUPABASE_SERVICE_ROLE_KEY } =
-  requireSupabaseEnv({ requireServiceRole: true });
+const {
+  supabaseUrl: SUPABASE_URL,
+  supabaseAnonKey: SUPABASE_ANON_KEY,
+  supabaseServiceRoleKey: SUPABASE_SERVICE_ROLE_KEY,
+} = requireSupabaseEnv({ requireServiceRole: true });
 
 const required = {
   PRESIGN_URL,

--- a/scripts/security/r2-presign-smoke.mjs
+++ b/scripts/security/r2-presign-smoke.mjs
@@ -11,19 +11,16 @@
 
 import { randomUUID } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
+import { requireSupabaseEnv } from "../infra/load-supabase-env.mjs";
 
 const PRESIGN_URL = process.env.PRESIGN_URL;
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN;
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS;
-const SUPABASE_URL = process.env.SUPABASE_URL;
-const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const { supabaseUrl: SUPABASE_URL, supabaseAnonKey: SUPABASE_ANON_KEY, supabaseServiceRoleKey: SUPABASE_SERVICE_ROLE_KEY } =
+  requireSupabaseEnv({ requireServiceRole: true });
 
 const required = {
   PRESIGN_URL,
-  SUPABASE_URL,
-  SUPABASE_ANON_KEY,
-  SUPABASE_SERVICE_ROLE_KEY,
 };
 
 const missing = Object.entries(required)

--- a/src/lib/storage/r2client.ts
+++ b/src/lib/storage/r2client.ts
@@ -49,6 +49,7 @@ const requestPresignedUpload = async (
   folderPath: R2UploadFolder,
 ): Promise<PresignResponse> => {
   const fileExt = assertAllowedUpload(file, folderPath);
+  const contentType = file.type.trim().toLowerCase();
   const accessToken = await getAuthSessionToken("upload files");
 
   let presignRes: Response;
@@ -60,7 +61,7 @@ const requestPresignedUpload = async (
         Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify({
-        contentType: file.type,
+        contentType,
         contentLength: file.size,
         fileExt,
         folderPath,
@@ -105,14 +106,19 @@ const requestPresignedUpload = async (
   };
 };
 
-const uploadToPresignedUrl = async (file: File, signedUrl: string): Promise<void> => {
+const uploadToPresignedUrl = async (
+  file: File,
+  signedUrl: string,
+  contentType: string,
+): Promise<void> => {
   let uploadRes: Response;
+  const uploadHost = new URL(signedUrl).host;
 
   try {
     uploadRes = await fetch(signedUrl, {
       method: "PUT",
       body: file,
-      headers: { "Content-Type": file.type },
+      headers: { "Content-Type": contentType },
     });
   } catch (error) {
     const message =
@@ -120,7 +126,7 @@ const uploadToPresignedUrl = async (file: File, signedUrl: string): Promise<void
         ? error.message
         : "Unknown browser network error while uploading to R2.";
     throw new Error(
-      `Upload request failed before reaching R2. Check browser/network policy for presigned PUT URL. ${message}`,
+      `Upload to R2 blocked (${uploadHost}). Check R2 bucket CORS on the same bucket as R2_BUCKET_NAME: AllowedOrigins must include ${typeof window !== "undefined" ? window.location.origin : "your site origin"}, and AllowedHeaders must include Content-Type (the same header sent on PUT in r2client.ts). See README → R2 bucket CORS. ${message}`,
     );
   }
 
@@ -134,7 +140,7 @@ const uploadToPresignedUrl = async (file: File, signedUrl: string): Promise<void
     }
 
     const message = errorText.trim() || uploadRes.statusText;
-    throw new Error(`Failed to upload to R2: ${message}`);
+    throw new Error(`Failed to upload to R2 (${uploadRes.status}): ${message}`);
   }
 };
 
@@ -183,8 +189,9 @@ export const uploadToR2 = async (
   file: File,
   folderPath: R2UploadFolder = R2_UPLOAD_FOLDERS.media,
 ): Promise<string> => {
+  const contentType = file.type.trim().toLowerCase();
   const { signedUrl, publicUrl } = await requestPresignedUpload(file, folderPath);
-  await uploadToPresignedUrl(file, signedUrl);
+  await uploadToPresignedUrl(file, signedUrl, contentType);
 
   return publicUrl;
 };

--- a/src/lib/storage/r2client.ts
+++ b/src/lib/storage/r2client.ts
@@ -29,6 +29,7 @@ const PRESIGN_FUNCTION_URL = new URL(
 interface PresignResponse {
   signedUrl: string;
   publicUrl: string;
+  contentType: string;
 }
 
 const getAuthSessionToken = async (actionDescription = "perform this action"): Promise<string> => {
@@ -103,6 +104,7 @@ const requestPresignedUpload = async (
   return {
     signedUrl: signedUrlParsed.href,
     publicUrl: publicUrlParsed.href,
+    contentType,
   };
 };
 
@@ -189,8 +191,7 @@ export const uploadToR2 = async (
   file: File,
   folderPath: R2UploadFolder = R2_UPLOAD_FOLDERS.media,
 ): Promise<string> => {
-  const contentType = file.type.trim().toLowerCase();
-  const { signedUrl, publicUrl } = await requestPresignedUpload(file, folderPath);
+  const { signedUrl, publicUrl, contentType } = await requestPresignedUpload(file, folderPath);
   await uploadToPresignedUrl(file, signedUrl, contentType);
 
   return publicUrl;

--- a/supabase/functions/_shared/logger.ts
+++ b/supabase/functions/_shared/logger.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Guy Erreich
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** Structured JSON logger for Supabase Edge Functions (Deno). */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogContext = Record<string, unknown>;
+
+export interface Logger {
+  debug(message: string, context?: LogContext): void;
+  info(message: string, context?: LogContext): void;
+  warn(message: string, context?: LogContext): void;
+  error(message: string, context?: LogContext): void;
+  child(bindings: LogContext): Logger;
+}
+
+const LOG_LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const resolveMinLevel = (): LogLevel => {
+  const raw = (Deno.env.get("LOG_LEVEL") ?? "info").trim().toLowerCase();
+  if (raw === "debug" || raw === "info" || raw === "warn" || raw === "error") {
+    return raw;
+  }
+  return "info";
+};
+
+const MIN_LOG_LEVEL = resolveMinLevel();
+
+const shouldLog = (level: LogLevel): boolean => LOG_LEVEL_RANK[level] >= LOG_LEVEL_RANK[MIN_LOG_LEVEL];
+
+const writeLog = (level: LogLevel, scope: string, message: string, bindings: LogContext): void => {
+  if (!shouldLog(level)) {
+    return;
+  }
+
+  const entry = {
+    ts: new Date().toISOString(),
+    level,
+    scope,
+    msg: message,
+    ...bindings,
+  };
+
+  const line = JSON.stringify(entry);
+
+  if (level === "error") {
+    console.error(line);
+    return;
+  }
+
+  if (level === "warn") {
+    console.warn(line);
+    return;
+  }
+
+  console.log(line);
+};
+
+const createLoggerImpl = (scope: string, bindings: LogContext): Logger => ({
+  debug(message: string, context?: LogContext): void {
+    writeLog("debug", scope, message, { ...bindings, ...context });
+  },
+
+  info(message: string, context?: LogContext): void {
+    writeLog("info", scope, message, { ...bindings, ...context });
+  },
+
+  warn(message: string, context?: LogContext): void {
+    writeLog("warn", scope, message, { ...bindings, ...context });
+  },
+
+  error(message: string, context?: LogContext): void {
+    writeLog("error", scope, message, { ...bindings, ...context });
+  },
+
+  child(childBindings: LogContext): Logger {
+    return createLoggerImpl(scope, { ...bindings, ...childBindings });
+  },
+});
+
+/** Creates a scoped logger. Optional bindings are included on every log line. */
+export const createLogger = (scope: string, bindings: LogContext = {}): Logger =>
+  createLoggerImpl(scope, bindings);

--- a/supabase/functions/r2-presign/index.ts
+++ b/supabase/functions/r2-presign/index.ts
@@ -13,10 +13,12 @@
 //   R2_BUCKET_NAME, R2_PUBLIC_URL
 //   ALLOWED_ORIGINS  — comma-separated list of allowed frontend origins
 //                      e.g. "https://abc.pages.dev,https://yourdomain.com"
+//   LOG_LEVEL        — optional: debug | info | warn | error (default: info)
 
 import { DeleteObjectCommand, PutObjectCommand, S3Client } from "npm:@aws-sdk/client-s3@3.1026.0";
 import { getSignedUrl } from "npm:@aws-sdk/s3-request-presigner@3.1026.0";
 import { createClient } from "npm:@supabase/supabase-js@2.102.1";
+import { createLogger } from "../_shared/logger.ts";
 
 // Allowed origins for CORS — configured per environment via the ALLOWED_ORIGINS secret.
 // Set it to a comma-separated list, e.g.:
@@ -29,6 +31,15 @@ const ALLOWED_ORIGINS = new Set(
     .filter(Boolean),
 );
 const HAS_ALLOWED_ORIGINS = ALLOWED_ORIGINS.size > 0;
+
+const logger = createLogger("r2-presign");
+
+logger.info("Edge function bootstrapped", {
+  allowedOriginsCount: ALLOWED_ORIGINS.size,
+  allowedOrigins: [...ALLOWED_ORIGINS].sort(),
+  hasAllowedOrigins: HAS_ALLOWED_ORIGINS,
+  logLevel: Deno.env.get("LOG_LEVEL") ?? "info",
+});
 
 // UPLOAD POLICY DUPLICATION NOTICE:
 // This object mirrors the shared client contract in `src/lib/storage/r2UploadPolicies.ts`:
@@ -124,9 +135,19 @@ function errorCorsHeaders(origin: string): Record<string, string> {
 }
 
 Deno.serve(async (req: Request) => {
+  const requestId = crypto.randomUUID();
+  const requestLogger = logger.child({ requestId });
   const origin = req.headers.get("Origin") ?? "";
+  const requestUrl = new URL(req.url);
+
+  requestLogger.info("Request received", {
+    method: req.method,
+    path: requestUrl.pathname,
+    requestOrigin: origin || "(none)",
+  });
 
   if (!HAS_ALLOWED_ORIGINS) {
+    requestLogger.error("ALLOWED_ORIGINS secret is missing or empty");
     return new Response(
       JSON.stringify({ error: "Server misconfigured: ALLOWED_ORIGINS secret is missing or empty" }),
       {
@@ -141,6 +162,10 @@ Deno.serve(async (req: Request) => {
   // Reject requests from origins not in the allowlist.
   // Return 403 with no ACAO header — the browser will block the response.
   if (!CORS) {
+    requestLogger.warn("CORS origin rejected", {
+      requestOrigin: origin || "(none)",
+      allowedOrigins: [...ALLOWED_ORIGINS].sort(),
+    });
     return new Response(null, { status: 403 });
   }
 
@@ -155,10 +180,14 @@ Deno.serve(async (req: Request) => {
 
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
+    requestLogger.info("CORS preflight handled", {
+      requestOrigin: origin,
+    });
     return new Response("ok", { headers: CORS });
   }
 
   if (req.method !== "POST" && req.method !== "DELETE") {
+    requestLogger.warn("Method not allowed", { method: req.method });
     return json({ error: "Method not allowed" }, 405);
   }
 
@@ -166,9 +195,11 @@ Deno.serve(async (req: Request) => {
     // --- Auth: verify the caller has a valid Supabase session ---
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) {
+      requestLogger.warn("Missing Authorization header");
       return json({ error: "Missing Authorization header" }, 401);
     }
     if (!authHeader.startsWith("Bearer ")) {
+      requestLogger.warn("Invalid Authorization header format");
       return json({ error: "Invalid Authorization header" }, 401);
     }
 
@@ -187,6 +218,9 @@ Deno.serve(async (req: Request) => {
       error: authError,
     } = await supabase.auth.getUser();
     if (authError || !user) {
+      requestLogger.warn("Authentication failed", {
+        authError: authError?.message ?? "no user returned",
+      });
       return json({ error: "Unauthorized" }, 401);
     }
     const roleValue = user.app_metadata?.roles;
@@ -196,8 +230,11 @@ Deno.serve(async (req: Request) => {
     };
     const isAdmin = isAdminRole(roleValue);
     if (!isAdmin) {
+      requestLogger.warn("Forbidden — caller is not admin", { userId: user.id });
       return json({ error: "Forbidden" }, 403);
     }
+
+    requestLogger.info("Authenticated admin", { userId: user.id });
 
     // --- Parse request ---
     let body: unknown;
@@ -283,6 +320,11 @@ Deno.serve(async (req: Request) => {
         }),
       );
 
+      requestLogger.info("R2 object deleted", {
+        objectFolder,
+        objectKey,
+      });
+
       return json({ ok: true });
     }
 
@@ -351,9 +393,20 @@ Deno.serve(async (req: Request) => {
     // Presigned URL valid for 15 minutes — enough for a video upload
     const signedUrl = await getSignedUrl(r2, command, { expiresIn: 900 });
 
+    requestLogger.info("Presigned upload URL issued", {
+      folder,
+      contentType: normalizedContentType,
+      contentLength,
+      fileExt: extNoDot,
+      objectKey: key,
+    });
+
     return json({ signedUrl, publicUrl: `${publicUrl}/${key}` });
   } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
+    requestLogger.error("Unhandled error", {
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     return json({ error: "Internal server error" }, 500);
   }
 });

--- a/supabase/functions/r2-presign/index.ts
+++ b/supabase/functions/r2-presign/index.ts
@@ -32,13 +32,16 @@ const ALLOWED_ORIGINS = new Set(
 );
 const HAS_ALLOWED_ORIGINS = ALLOWED_ORIGINS.size > 0;
 
+const LOG_LEVEL = (Deno.env.get("LOG_LEVEL") ?? "info").trim().toLowerCase();
+const IS_DEBUG_LOG_LEVEL = LOG_LEVEL === "debug";
+
 const logger = createLogger("r2-presign");
 
 logger.info("Edge function bootstrapped", {
   allowedOriginsCount: ALLOWED_ORIGINS.size,
-  allowedOrigins: [...ALLOWED_ORIGINS].sort(),
+  ...(IS_DEBUG_LOG_LEVEL ? { allowedOrigins: [...ALLOWED_ORIGINS].sort() } : {}),
   hasAllowedOrigins: HAS_ALLOWED_ORIGINS,
-  logLevel: Deno.env.get("LOG_LEVEL") ?? "info",
+  logLevel: LOG_LEVEL,
 });
 
 // UPLOAD POLICY DUPLICATION NOTICE:
@@ -164,7 +167,8 @@ Deno.serve(async (req: Request) => {
   if (!CORS) {
     requestLogger.warn("CORS origin rejected", {
       requestOrigin: origin || "(none)",
-      allowedOrigins: [...ALLOWED_ORIGINS].sort(),
+      allowedOriginsCount: ALLOWED_ORIGINS.size,
+      ...(IS_DEBUG_LOG_LEVEL ? { allowedOrigins: [...ALLOWED_ORIGINS].sort() } : {}),
     });
     return new Response(null, { status: 403 });
   }


### PR DESCRIPTION
## Summary
- Add structured JSON logging to `r2-presign` (boot allowed origins, per-request CORS/auth/presign events)
- Improve client upload errors and normalize `Content-Type` on presign + PUT
- Document two-layer CORS (Supabase `ALLOWED_ORIGINS` vs R2 bucket CORS) in README
- Add infra scripts: `infra:get-r2-cors`, `infra:apply-r2-cors`, env loaders for `R2_*` / `SUPABASE_*`
- Fix `.env.example`: remove `VITE_R2_*` secrets; use `R2_*` for local tooling only

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Deploy `r2-presign` and confirm boot log shows `allowedOrigins`
- [ ] Admin media upload: presign POST 200, R2 PUT 200 (after bucket CORS configured)
- [ ] `npm run infra:get-r2-cors` reads `.env.local` / `.env` with `R2_*` names (admin token required)

## Ops note
R2 bucket CORS remains a one-time Cloudflare dashboard / infra script step — not applied by this PR automatically.