### PR TITLE
Accept gateway 403 in security smoke auth tests

### DIFF
--- a/scripts/security/github-project-seed-smoke.mjs
+++ b/scripts/security/github-project-seed-smoke.mjs
@@ -174,7 +174,7 @@ const run = async () => {
       {
         name: "rejects missing authorization",
         method: "POST",
-        expectedStatus: 401,
+        expectedStatus: [401, 403],
         headers: headersBase,
         body: { repoUrl: GITHUB_SEED_TEST_REPO_URL },
       },

--- a/scripts/security/r2-presign-smoke.mjs
+++ b/scripts/security/r2-presign-smoke.mjs
@@ -125,7 +125,7 @@ const createUserAndToken = async ({ email, password, appMetadata }) => {
 const buildPostTests = ({ adminJwt, userJwt }) => [
   {
     name: "rejects missing authorization",
-    expectedStatus: 401,
+    expectedStatus: [401, 403],
     headers: headersBase,
     body: {
       contentType: "video/mp4",
@@ -136,7 +136,7 @@ const buildPostTests = ({ adminJwt, userJwt }) => [
   },
   {
     name: "rejects malformed authorization",
-    expectedStatus: 401,
+    expectedStatus: [401, 403],
     headers: { ...headersBase, Authorization: "Token invalid" },
     body: {
       contentType: "video/mp4",
@@ -217,7 +217,7 @@ const buildDeleteTests = ({ adminJwt, userJwt, validPublicUrl }) => [
   {
     name: "delete rejects missing authorization",
     method: "DELETE",
-    expectedStatus: 401,
+    expectedStatus: [401, 403],
     headers: headersBase,
     body: { publicUrl: validPublicUrl },
   },


### PR DESCRIPTION
## Summary
- Update `github-project-seed-smoke` and `r2-presign-smoke` to accept **401 or 403** for missing/malformed `Authorization` cases.
- Unblocks the deploy workflow smoke gate after PR #53 merged: Supabase's Functions gateway returns 403 before edge functions can return 401 when no bearer token is sent.

## Test plan
- [ ] CI smoke workflows pass on this PR (`github-project-seed-security-smoke`, `r2-presign-security-smoke`)
- [ ] After merge to `dev`, deploy workflow smoke gate succeeds and Pages deploy runs