### PR TITLE
Fix browser R2 uploads (presign signing, apikey, CORS tooling)

### DIFF
--- a/.cursor/skills/project/platform/supabase-branch-testing/SKILL.md
+++ b/.cursor/skills/project/platform/supabase-branch-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: supabase-branch-testing
-description: Creates temporary Supabase branch environments for localhost testing without relaxing production CORS. Use when validating schema or auth changes against a branch before merge.
+description: Creates temporary Supabase branch environments for preview-origin testing. Use when validating schema or auth changes against a branch before merge.
 disable-model-invocation: true
 ---
 
@@ -14,14 +14,14 @@ This skill is intentionally thin. It routes to one reference at a time and stops
 
 ## Outcome
 - Create and use a temporary branch safely.
-- Keep localhost CORS branch-only.
+- Use preview URLs in branch `ALLOWED_ORIGINS`; never loopback.
 - Validate the requested flow.
 - Clean up branch resources.
 
 ## Load Order (Lazy)
 1. Confirm project and branch-testing intent.
 2. Load [Temporary Branch Testing Workflow](../supabase/references/branch-testing-workflow.md).
-3. Load [Localhost Origins Source](../supabase/references/localhost-origins.md) only when setting CORS secrets.
+3. Load [Localhost and ALLOWED_ORIGINS](../supabase/references/localhost-origins.md) when setting `ALLOWED_ORIGINS`.
 4. Load one deeper workflow only if needed:
 - [Schema Change Workflow](../supabase/references/schema-change-workflow.md)
 - [Edge Function Workflow](../supabase/references/edge-function-workflow.md)
@@ -41,7 +41,7 @@ This skill is intentionally thin. It routes to one reference at a time and stops
 ## Rules
 - Prefer MCP branch/project tools first.
 - Use CLI fallback only if MCP coverage is missing.
-- Never relax production CORS for localhost testing.
+- Never add localhost/loopback to `ALLOWED_ORIGINS`.
 - Do not preload schema/function/advisor docs unless task requires them.
 
 ## Stop Conditions

--- a/.cursor/skills/project/platform/supabase/SKILL.md
+++ b/.cursor/skills/project/platform/supabase/SKILL.md
@@ -36,13 +36,13 @@ Use this skill as a thin router. It should classify intent, load one small refer
 - Load [Edge Function Workflow](./references/edge-function-workflow.md).
 5. Advisor-driven review:
 - Load [Advisor Workflow](./references/advisor-workflow.md).
-6. Temporary branch localhost testing:
+6. Temporary branch / preview testing:
 - Load [Temporary Branch Testing Workflow](./references/branch-testing-workflow.md).
-- For localhost origin values, load [Localhost Origins Source](./references/localhost-origins.md).
+- When configuring `ALLOWED_ORIGINS` on a branch, load [Localhost and ALLOWED_ORIGINS](./references/localhost-origins.md) (preview URLs only).
 
 ## Hard Rules
 - Prefer MCP tools first, CLI only when MCP coverage is missing.
-- Never apply localhost CORS to production settings.
+- Never put localhost/loopback in `ALLOWED_ORIGINS` (any environment).
 - Never run ad-hoc DDL via raw SQL when migration flow applies.
 - Never load unrelated references.
 
@@ -65,4 +65,4 @@ Always return:
 - [Edge Function Workflow](./references/edge-function-workflow.md)
 - [Advisor Workflow](./references/advisor-workflow.md)
 - [Temporary Branch Testing Workflow](./references/branch-testing-workflow.md)
-- [Localhost Origins Source](./references/localhost-origins.md)
+- [Localhost and ALLOWED_ORIGINS](./references/localhost-origins.md)

--- a/.cursor/skills/project/platform/supabase/references/branch-testing-workflow.md
+++ b/.cursor/skills/project/platform/supabase/references/branch-testing-workflow.md
@@ -38,5 +38,5 @@ Use preview deployment URLs on the branch secret — never localhost or loopback
 ## Cleanup checklist
 - Remove branch-only secrets.
 - Delete the temporary branch.
-- Confirm production CORS remains unchanged.
+- Confirm production ALLOWED_ORIGINS and R2 CORS remain unchanged.
 - Re-run a quick validation pass if schema or runtime code changed.

--- a/.cursor/skills/project/platform/supabase/references/branch-testing-workflow.md
+++ b/.cursor/skills/project/platform/supabase/references/branch-testing-workflow.md
@@ -1,15 +1,15 @@
 # Temporary Branch Testing Workflow
 
-Use this workflow when you need to test the app from localhost without loosening production CORS.
+Use this workflow when you need an isolated Supabase environment without changing production secrets.
 
 ## When to use
-- You need a short-lived Supabase environment for local testing.
-- You want localhost origins allowed only in the temporary branch.
+- You need a short-lived Supabase environment for integration testing.
+- You want preview-only origins in `ALLOWED_ORIGINS`, separate from production.
 - You want to keep production settings strict.
 
 ## Required outcome
 - Temporary branch project exists.
-- Branch-only CORS allows localhost.
+- Branch `ALLOWED_ORIGINS` lists deployed preview URLs only (no localhost — see [Localhost and ALLOWED_ORIGINS](./localhost-origins.md)).
 - App points at the branch project only while testing.
 - Temporary branch is deleted after validation.
 
@@ -17,9 +17,9 @@ Use this workflow when you need to test the app from localhost without loosening
 1. Confirm the parent project and that the branch is temporary.
 2. Create the branch project with Supabase branch tools.
 3. Verify branch status and project details.
-4. Set branch secrets/config, including localhost-only CORS.
+4. Set branch secrets/config with preview URLs in `ALLOWED_ORIGINS`.
 5. Apply the needed migrations or deploy edge functions to the branch.
-6. Validate behavior from localhost.
+6. Validate behavior from the deployed preview origin.
 7. Re-run security/performance advisors if the branch changed schema or runtime logic.
 8. Delete the branch when done.
 
@@ -28,13 +28,12 @@ Use the Supabase CLI if MCP branch coverage is missing.
 
 1. Create the branch with the Supabase CLI branch commands.
 2. Set the branch-specific secrets with the CLI.
-3. Point local environment variables at the branch project URL and anon key.
-4. Run the app locally and verify the workflow.
+3. Point environment variables at the branch project URL and anon key.
+4. Deploy or open the app on a preview URL and verify the workflow.
 5. Delete the branch when testing is finished.
 
-## Localhost-only CORS guidance
-Use a temporary branch secret for localhost origins instead of adding localhost to production.
-Use the canonical value from [Localhost Origins Source](./localhost-origins.md).
+## ALLOWED_ORIGINS guidance
+Use preview deployment URLs on the branch secret — never localhost or loopback. See [Localhost and ALLOWED_ORIGINS](./localhost-origins.md).
 
 ## Cleanup checklist
 - Remove branch-only secrets.

--- a/.cursor/skills/project/platform/supabase/references/localhost-origins.md
+++ b/.cursor/skills/project/platform/supabase/references/localhost-origins.md
@@ -1,15 +1,11 @@
-# Localhost Origins Source
+# Localhost and ALLOWED_ORIGINS
 
-Use this file as the single source of truth for localhost origin allowlists.
-Do not duplicate these values in other Supabase skill or prompt files.
+**Localhost / loopback origins are never allowed in `ALLOWED_ORIGINS`.**
 
-## Canonical branch-only value
+Every user runs a local dev server, so `localhost`, `127.0.0.1`, and `[::1]` are not meaningful origin boundaries for Supabase edge-function CORS. They are filtered out by `parseAllowedOrigins` in all environments (production, preview, and branch).
 
-```text
-ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173
-```
+## Local testing workflow
 
-## Rules
-- Apply this value only to temporary development branches.
-- Never apply this value to production settings.
-- Update this file first if ports/origins change.
+Test edge functions and browser uploads from a **deployed preview origin** (e.g. Cloudflare Pages dev URL), not from `npm run dev` against production Supabase secrets.
+
+When you need schema or auth changes isolated from production, use a Supabase branch with preview URLs in `ALLOWED_ORIGINS` — still no localhost. See [Branch Testing Workflow](./branch-testing-workflow.md).

--- a/.github/workflows/github-project-seed-security-smoke.yml
+++ b/.github/workflows/github-project-seed-security-smoke.yml
@@ -36,19 +36,11 @@ jobs:
             seed_url="${PROJECT_SEED_URL:-}"
           fi
 
-          allowed_origin="${ALLOWED_ORIGIN:-}"
-          if [ -z "$allowed_origin" ]; then
-            raw_origins="${ALLOWED_ORIGINS:-}"
-            allowed_origin=""
-
-            # Extract first URL from common formats: comma list, newline list, or JSON-like array.
-            allowed_origin="$(
-              printf '%s' "$raw_origins" \
-                | tr '\n' ',' \
-                | grep -Eo 'https?://[^",[:space:]\]]+' \
-                | head -n 1
-            )"
-          fi
+          allowed_origin="$(
+            ALLOWED_ORIGIN="${ALLOWED_ORIGIN:-}" \
+              ALLOWED_ORIGINS="${ALLOWED_ORIGINS:-}" \
+              node scripts/infra/resolve-smoke-allowed-origin.mjs
+          )"
 
           {
             echo "GITHUB_SEED_URL=$seed_url"

--- a/.github/workflows/r2-presign-security-smoke.yml
+++ b/.github/workflows/r2-presign-security-smoke.yml
@@ -36,19 +36,11 @@ jobs:
             presign_url="${PRESIGN_URL:-}"
           fi
 
-          allowed_origin="${ALLOWED_ORIGIN:-}"
-          if [ -z "$allowed_origin" ]; then
-            raw_origins="${ALLOWED_ORIGINS:-}"
-            allowed_origin=""
-
-            # Extract first URL from common formats: comma list, newline list, or JSON-like array.
-            allowed_origin="$(
-              printf '%s' "$raw_origins" \
-                | tr '\n' ',' \
-                | grep -Eo 'https?://[^",[:space:]\]]+' \
-                | head -n 1
-            )"
-          fi
+          allowed_origin="$(
+            ALLOWED_ORIGIN="${ALLOWED_ORIGIN:-}" \
+              ALLOWED_ORIGINS="${ALLOWED_ORIGINS:-}" \
+              node scripts/infra/resolve-smoke-allowed-origin.mjs
+          )"
 
           {
             echo "PRESIGN_URL=$presign_url"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+
+      - name: Allowed-origins parser parity (Node + Deno)
+        run: npm run infra:check-allowed-origins
+
       - name: Lint (ESLint + Biome)
         run: npm run lint
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ npm install
 npm run dev
 ```
 
+**Optional — origin parser parity:** `npm run infra:check-allowed-origins` validates the Node and Deno `ALLOWED_ORIGINS` parsers against shared fixtures. CI installs Deno automatically; for local runs, install [Deno](https://docs.deno.com/) first.
+
 ### Other Commands
 
 ```bash
@@ -249,7 +251,7 @@ npm run lint    # ESLint + Biome checks
 npm run preview # Serve the production build locally
 ```
 
-Security smoke tests for `r2-presign`:
+Security smoke tests for `r2-presign` (use a deployed preview/production origin — loopback is rejected):
 
 ```bash
 PRESIGN_URL=https://<ref>.supabase.co/functions/v1/r2-presign \

--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ supabase secrets set ALLOWED_ORIGINS=<comma-separated-allowed-origins>
 supabase secrets set LOG_LEVEL=info   # optional: debug | info | warn | error
 ```
 
-**ALLOWED_ORIGINS format rule:** use either full URLs (`https://site.pages.dev,https://other.com`) **or** domain-only shorthand (`example.com,localhost:5173`) — not both in one secret. If any full URL is present, domain-only entries are ignored (intentional guardrail so prod secrets cannot accidentally pick up localhost shorthand). For localhost dev, use a Supabase branch secret with full `http://localhost:5173` URLs — never mix prod URLs with localhost in production settings.
+**ALLOWED_ORIGINS rules:**
+- **No localhost / loopback origins** — `localhost`, `127.0.0.1`, and `[::1]` are always rejected. Every user runs a local server, so loopback is not a meaningful origin boundary for edge-function CORS. Test uploads and edge functions from a deployed preview URL (e.g. Cloudflare Pages dev), not `npm run dev` against production Supabase secrets.
+- **Format rule:** use either full URLs (`https://site.pages.dev,https://other.com`) **or** domain-only shorthand (`example.com,other.com`) — not both in one secret. If any full URL is present, domain-only entries in the same value are ignored.
 
 Admin authorization for `r2-presign` is based on Supabase Auth metadata (`app_metadata.roles` contains `"admin"`), not an email allowlist secret.
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ supabase secrets set ALLOWED_ORIGINS=<comma-separated-allowed-origins>
 supabase secrets set LOG_LEVEL=info   # optional: debug | info | warn | error
 ```
 
+**ALLOWED_ORIGINS format rule:** use either full URLs (`https://site.pages.dev,https://other.com`) **or** domain-only shorthand (`example.com,localhost:5173`) — not both in one secret. If any full URL is present, domain-only entries are ignored (intentional guardrail so prod secrets cannot accidentally pick up localhost shorthand). For localhost dev, use a Supabase branch secret with full `http://localhost:5173` URLs — never mix prod URLs with localhost in production settings.
+
 Admin authorization for `r2-presign` is based on Supabase Auth metadata (`app_metadata.roles` contains `"admin"`), not an email allowlist secret.
 
 Deploy the edge function after setting secrets:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Alternatively, set CORS in Cloudflare Dashboard → R2 → your bucket → Setti
 **Important R2 CORS gotchas:**
 - CORS must be on the **same bucket** as your `R2_BUCKET_NAME` Supabase secret (not the public custom domain).
 - `AllowedOrigins` must match `window.location.origin` exactly (no trailing slash).
-- `AllowedHeaders` must include `Content-Type` (same HTTP header the browser sends on PUT — see `r2client.ts`). If uploads still fail, try lowercase `content-type` in the dashboard; R2 CORS matching can be picky even though HTTP header names are case-insensitive.
+- `AllowedHeaders` must include `Content-Type` (same HTTP header the browser sends on PUT — see `r2client.ts`). If uploads still fail, use lowercase `content-type` in the R2 CORS policy; R2 preflight matching can be picky even though HTTP header names are case-insensitive.
 - Dashboard JSON is a **top-level array** (not a `"rules"` wrapper).
 - Changes can take ~30 seconds to propagate.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ supabase secrets set LOG_LEVEL=info   # optional: debug | info | warn | error
 ```
 
 **ALLOWED_ORIGINS rules:**
-- **No localhost / loopback origins** — `localhost`, `127.0.0.1`, and `[::1]` are always rejected. Every user runs a local server, so loopback is not a meaningful origin boundary for edge-function CORS. Test uploads and edge functions from a deployed preview URL (e.g. Cloudflare Pages dev), not `npm run dev` against production Supabase secrets.
+- **No localhost / loopback origins** — `localhost`, `127.0.0.1`, `0.0.0.0`, and `[::1]` are always rejected. Every user runs a local server, so loopback is not a meaningful origin boundary for edge-function CORS. Test uploads and edge functions from a deployed preview URL (e.g. Cloudflare Pages dev), not `npm run dev` against production Supabase secrets.
 - **Format rule:** use either full URLs (`https://site.pages.dev,https://other.com`) **or** domain-only shorthand (`example.com,other.com`) — not both in one secret. If any full URL is present, domain-only entries in the same value are ignored.
 
 Admin authorization for `r2-presign` is based on Supabase Auth metadata (`app_metadata.roles` contains `"admin"`), not an email allowlist secret.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "security:test:github-seed": "node scripts/security/github-project-seed-smoke.mjs",
     "infra:apply-r2-cors": "node scripts/infra/apply-r2-cors.mjs",
     "infra:get-r2-cors": "node scripts/infra/get-r2-cors.mjs",
+    "infra:check-allowed-origins": "node scripts/infra/parse-allowed-origins-parity.mjs",
     "format": "biome format --write .",
     "preview": "vite preview"
   },

--- a/scripts/infra/allowed-origins-deno-parity.ts
+++ b/scripts/infra/allowed-origins-deno-parity.ts
@@ -1,0 +1,42 @@
+/**
+ * Parity check for supabase/functions/_shared/allowedOrigins.ts against shared fixtures.
+ * Invoked by scripts/infra/parse-allowed-origins-parity.mjs (requires Deno).
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseAllowedOrigins } from "../../supabase/functions/_shared/allowedOrigins.ts";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const fixturesPath = resolve(scriptDir, "allowed-origins-fixtures.json");
+const fixtures = JSON.parse(readFileSync(fixturesPath, "utf8")) as Array<{
+  name: string;
+  input: string;
+  expected: string[];
+}>;
+
+let failed = 0;
+
+for (const fixture of fixtures) {
+  const actual = [...parseAllowedOrigins(fixture.input)].sort();
+  const expected = [...fixture.expected].sort();
+
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+
+  if (actualJson !== expectedJson) {
+    failed += 1;
+    console.error(`FAIL [Deno]: ${fixture.name}`);
+    console.error(`  input:    ${JSON.stringify(fixture.input)}`);
+    console.error(`  expected: ${expectedJson}`);
+    console.error(`  actual:   ${actualJson}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`${failed} Deno fixture(s) failed.`);
+  Deno.exit(1);
+}
+
+console.warn(`All ${fixtures.length} allowed-origins Deno fixtures passed.`);

--- a/scripts/infra/allowed-origins-fixtures.json
+++ b/scripts/infra/allowed-origins-fixtures.json
@@ -16,8 +16,13 @@
   },
   {
     "name": "domain-only entries",
-    "input": "example.com,localhost:5173",
-    "expected": ["https://example.com", "http://localhost:5173"]
+    "input": "example.com,other.com",
+    "expected": ["https://example.com", "https://other.com"]
+  },
+  {
+    "name": "localhost URLs are rejected",
+    "input": "https://a.pages.dev,http://localhost:5173,http://127.0.0.1:5173",
+    "expected": ["https://a.pages.dev"]
   },
   {
     "name": "trailing slash on URL",

--- a/scripts/infra/allowed-origins-fixtures.json
+++ b/scripts/infra/allowed-origins-fixtures.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "empty string",
+    "input": "",
+    "expected": []
+  },
+  {
+    "name": "comma-separated list",
+    "input": "https://a.pages.dev,https://b.pages.dev",
+    "expected": ["https://a.pages.dev", "https://b.pages.dev"]
+  },
+  {
+    "name": "JSON-like array",
+    "input": "[\"https://a.pages.dev\",\"https://b.pages.dev\"]",
+    "expected": ["https://a.pages.dev", "https://b.pages.dev"]
+  },
+  {
+    "name": "domain-only entries",
+    "input": "example.com,localhost:5173",
+    "expected": ["https://example.com", "http://localhost:5173"]
+  },
+  {
+    "name": "trailing slash on URL",
+    "input": "https://site.com/",
+    "expected": ["https://site.com"]
+  },
+  {
+    "name": "escaped slashes in JSON copy",
+    "input": "[\"https:\\/\\/a.pages.dev\"]",
+    "expected": ["https://a.pages.dev"]
+  }
+]

--- a/scripts/infra/allowed-origins-fixtures.json
+++ b/scripts/infra/allowed-origins-fixtures.json
@@ -33,5 +33,15 @@
     "name": "escaped slashes in JSON copy",
     "input": "[\"https:\\/\\/a.pages.dev\"]",
     "expected": ["https://a.pages.dev"]
+  },
+  {
+    "name": "mixed URL and domain-only drops domains",
+    "input": "https://a.pages.dev,example.com",
+    "expected": ["https://a.pages.dev"]
+  },
+  {
+    "name": "0.0.0.0 loopback is rejected",
+    "input": "https://a.pages.dev,https://0.0.0.0:5173",
+    "expected": ["https://a.pages.dev"]
   }
 ]

--- a/scripts/infra/apply-r2-cors.mjs
+++ b/scripts/infra/apply-r2-cors.mjs
@@ -22,6 +22,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { PutBucketCorsCommand, S3Client } from "@aws-sdk/client-s3";
 import { requireR2Env } from "./load-r2-env.mjs";
+import { parseAllowedOrigins } from "./parse-allowed-origins.mjs";
 
 const { accountId, accessKeyId, secretAccessKey, bucket } = requireR2Env();
 const corsOriginsEnv = process.env.R2_CORS_ORIGINS;
@@ -29,10 +30,7 @@ const corsFile = process.env.R2_CORS_FILE ?? "scripts/infra/r2-cors.json";
 
 const loadCorsRules = () => {
   if (typeof corsOriginsEnv === "string" && corsOriginsEnv.trim().length > 0) {
-    const origins = corsOriginsEnv
-      .split(",")
-      .map((o) => o.trim())
-      .filter(Boolean);
+    const origins = parseAllowedOrigins(corsOriginsEnv);
 
     if (origins.length === 0) {
       throw new Error("R2_CORS_ORIGINS is empty after parsing.");

--- a/scripts/infra/apply-r2-cors.mjs
+++ b/scripts/infra/apply-r2-cors.mjs
@@ -42,7 +42,8 @@ const loadCorsRules = () => {
       {
         AllowedOrigins: origins,
         AllowedMethods: ["PUT", "GET", "HEAD"],
-        AllowedHeaders: ["Content-Type", "Content-Length"],
+        // R2 matches preflight literally — use lowercase header names (not "*").
+        AllowedHeaders: ["content-type", "content-length"],
         ExposeHeaders: ["ETag"],
         MaxAgeSeconds: 3600,
       },
@@ -71,11 +72,25 @@ const s3 = new S3Client({
 console.warn(`Applying R2 bucket CORS to "${bucket}"...`);
 console.warn(JSON.stringify(corsRules, null, 2));
 
-await s3.send(
-  new PutBucketCorsCommand({
-    Bucket: bucket,
-    CORSConfiguration: { CORSRules: corsRules },
-  }),
-);
+try {
+  await s3.send(
+    new PutBucketCorsCommand({
+      Bucket: bucket,
+      CORSConfiguration: { CORSRules: corsRules },
+    }),
+  );
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("AccessDenied") || message.includes("Access Denied")) {
+    console.error(
+      `R2 API token cannot update bucket CORS (AccessDenied). Use Cloudflare Dashboard instead:`,
+    );
+    console.error(`  R2 → bucket "${bucket}" → Settings → CORS policy`);
+    console.error("Paste this JSON (top-level array):");
+    console.error(JSON.stringify(corsRules, null, 2));
+    process.exit(1);
+  }
+  throw error;
+}
 
 console.warn("R2 bucket CORS applied successfully.");

--- a/scripts/infra/apply-r2-cors.mjs
+++ b/scripts/infra/apply-r2-cors.mjs
@@ -28,6 +28,14 @@ const { accountId, accessKeyId, secretAccessKey, bucket } = requireR2Env();
 const corsOriginsEnv = process.env.R2_CORS_ORIGINS;
 const corsFile = process.env.R2_CORS_FILE ?? "scripts/infra/r2-cors.json";
 
+const normalizeCorsRules = (rules) =>
+  rules.map((rule) => ({
+    ...rule,
+    AllowedHeaders: Array.isArray(rule.AllowedHeaders)
+      ? rule.AllowedHeaders.map((h) => String(h).toLowerCase())
+      : rule.AllowedHeaders,
+  }));
+
 const loadCorsRules = () => {
   if (typeof corsOriginsEnv === "string" && corsOriginsEnv.trim().length > 0) {
     const origins = parseAllowedOrigins(corsOriginsEnv);
@@ -56,7 +64,7 @@ const loadCorsRules = () => {
     throw new Error(`${corsFile} must be a non-empty JSON array of CORS rules.`);
   }
 
-  return parsed;
+  return normalizeCorsRules(parsed);
 };
 
 const corsRules = loadCorsRules();

--- a/scripts/infra/get-r2-cors.mjs
+++ b/scripts/infra/get-r2-cors.mjs
@@ -27,6 +27,16 @@ try {
     );
     process.exit(1);
   }
+  if (message.includes("AccessDenied") || message.includes("Access Denied")) {
+    console.error(
+      `R2 API token cannot read bucket CORS (AccessDenied). Check CORS in Cloudflare Dashboard:`,
+    );
+    console.error(`  R2 → bucket "${bucket}" → Settings → CORS policy`);
+    console.error(
+      "Required: your site origin in AllowedOrigins; content-type (lowercase) in AllowedHeaders; PUT in AllowedMethods.",
+    );
+    process.exit(1);
+  }
   console.error(message);
   process.exit(1);
 }

--- a/scripts/infra/parse-allowed-origins-parity.mjs
+++ b/scripts/infra/parse-allowed-origins-parity.mjs
@@ -1,0 +1,36 @@
+/*
+ * Parity check for scripts/infra/parse-allowed-origins.mjs against shared fixtures.
+ * When fixtures change, update supabase/functions/_shared/allowedOrigins.ts to match.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseAllowedOrigins } from "./parse-allowed-origins.mjs";
+
+const fixturesPath = resolve(import.meta.dirname, "allowed-origins-fixtures.json");
+const fixtures = JSON.parse(readFileSync(fixturesPath, "utf8"));
+
+let failed = 0;
+
+for (const fixture of fixtures) {
+  const actual = parseAllowedOrigins(fixture.input);
+  const expected = fixture.expected;
+
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+
+  if (actualJson !== expectedJson) {
+    failed += 1;
+    console.error(`FAIL: ${fixture.name}`);
+    console.error(`  input:    ${JSON.stringify(fixture.input)}`);
+    console.error(`  expected: ${expectedJson}`);
+    console.error(`  actual:   ${actualJson}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`${failed} fixture(s) failed.`);
+  process.exit(1);
+}
+
+console.warn(`All ${fixtures.length} allowed-origins fixtures passed.`);

--- a/scripts/infra/parse-allowed-origins-parity.mjs
+++ b/scripts/infra/parse-allowed-origins-parity.mjs
@@ -1,13 +1,18 @@
 /*
- * Parity check for scripts/infra/parse-allowed-origins.mjs against shared fixtures.
- * When fixtures change, update supabase/functions/_shared/allowedOrigins.ts to match.
+ * Parity check for allowed-origins parsers against shared fixtures.
+ * - Node: scripts/infra/parse-allowed-origins.mjs
+ * - Deno: supabase/functions/_shared/allowedOrigins.ts
+ *
+ * When fixtures change, update both parsers to match.
  */
 
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseAllowedOrigins } from "./parse-allowed-origins.mjs";
 
 const fixturesPath = resolve(import.meta.dirname, "allowed-origins-fixtures.json");
+const denoParityScript = resolve(import.meta.dirname, "allowed-origins-deno-parity.ts");
 const fixtures = JSON.parse(readFileSync(fixturesPath, "utf8"));
 
 let failed = 0;
@@ -21,7 +26,7 @@ for (const fixture of fixtures) {
 
   if (actualJson !== expectedJson) {
     failed += 1;
-    console.error(`FAIL: ${fixture.name}`);
+    console.error(`FAIL [Node]: ${fixture.name}`);
     console.error(`  input:    ${JSON.stringify(fixture.input)}`);
     console.error(`  expected: ${expectedJson}`);
     console.error(`  actual:   ${actualJson}`);
@@ -29,8 +34,31 @@ for (const fixture of fixtures) {
 }
 
 if (failed > 0) {
-  console.error(`${failed} fixture(s) failed.`);
+  console.error(`${failed} Node fixture(s) failed.`);
   process.exit(1);
 }
 
-console.warn(`All ${fixtures.length} allowed-origins fixtures passed.`);
+console.warn(`All ${fixtures.length} allowed-origins Node fixtures passed.`);
+
+const deno = spawnSync("deno", ["run", "--allow-read", denoParityScript], {
+  encoding: "utf8",
+  stdio: "pipe",
+});
+
+if (deno.error?.code === "ENOENT") {
+  console.error(
+    "Deno is required to validate supabase/functions/_shared/allowedOrigins.ts. Install Deno: https://docs.deno.com/runtime/getting_started/installation/",
+  );
+  process.exit(1);
+}
+
+if (deno.status !== 0) {
+  if (deno.stdout) process.stdout.write(deno.stdout);
+  if (deno.stderr) process.stderr.write(deno.stderr);
+  process.exit(deno.status ?? 1);
+}
+
+if (deno.stdout) process.stdout.write(deno.stdout);
+if (deno.stderr) process.stderr.write(deno.stderr);
+
+console.warn("Allowed-origins parity check passed (Node + Deno).");

--- a/scripts/infra/parse-allowed-origins-parity.mjs
+++ b/scripts/infra/parse-allowed-origins-parity.mjs
@@ -18,8 +18,8 @@ const fixtures = JSON.parse(readFileSync(fixturesPath, "utf8"));
 let failed = 0;
 
 for (const fixture of fixtures) {
-  const actual = parseAllowedOrigins(fixture.input);
-  const expected = fixture.expected;
+  const actual = [...parseAllowedOrigins(fixture.input)].sort();
+  const expected = [...fixture.expected].sort();
 
   const actualJson = JSON.stringify(actual);
   const expectedJson = JSON.stringify(expected);

--- a/scripts/infra/parse-allowed-origins.mjs
+++ b/scripts/infra/parse-allowed-origins.mjs
@@ -1,0 +1,48 @@
+/**
+ * Shared ALLOWED_ORIGINS parsing for Node smoke scripts.
+ * Keep behavior aligned with supabase/functions/_shared/allowedOrigins.ts.
+ */
+
+export const parseAllowedOrigins = (raw) => {
+  if (typeof raw !== "string") return [];
+
+  const normalized = raw.trim().replace(/\\\//g, "/");
+  if (!normalized) return [];
+
+  const urlCandidates = normalized.match(/https?:\/\/[^",\s\]]+/g);
+  if (urlCandidates && urlCandidates.length > 0) {
+    return [...new Set(urlCandidates.map((origin) => origin.trim()).filter(Boolean))];
+  }
+
+  const domainCandidates = normalized.match(
+    /(?:\*\.)?(?:localhost|[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)(?::\d{2,5})?/g,
+  );
+  if (domainCandidates && domainCandidates.length > 0) {
+    return [
+      ...new Set(
+        domainCandidates.map((domain) => {
+          const host = domain.replace(/^\*\./, "");
+          return host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
+        }),
+      ),
+    ];
+  }
+
+  return [
+    ...new Set(
+      normalized
+        .split(",")
+        .map((origin) => origin.trim().replace(/^["'\[]+|["'\]]+$/g, ""))
+        .filter(Boolean),
+    ),
+  ];
+};
+
+export const resolveAllowedOrigin = (singleOrigin, originList) => {
+  if (typeof singleOrigin === "string" && singleOrigin.trim().length > 0) {
+    return singleOrigin.trim();
+  }
+
+  const parsed = parseAllowedOrigins(originList ?? "");
+  return parsed[0];
+};

--- a/scripts/infra/parse-allowed-origins.mjs
+++ b/scripts/infra/parse-allowed-origins.mjs
@@ -2,7 +2,7 @@
  * Shared ALLOWED_ORIGINS parsing for Node smoke scripts.
  *
  * Security rules (always applied):
- * - Localhost / loopback origins are never accepted (`localhost`, `127.0.0.1`,
+ * - Localhost / loopback origins are never accepted (`localhost`, `127.0.0.1`, `0.0.0.0`,
  *   `[::1]`). Every user runs a local server, so they are not a meaningful
  *   origin boundary for edge-function CORS.
  * - Full URLs and domain-only shorthand are mutually exclusive in one secret:
@@ -28,15 +28,26 @@ const isLocalhostOrigin = (origin) => {
   try {
     const { hostname } = new URL(origin);
     const host = hostname.toLowerCase();
-    return host === "localhost" || host === "127.0.0.1" || host === "[::1]" || host === "::1";
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "0.0.0.0" ||
+      host === "[::1]" ||
+      host === "::1"
+    );
   } catch {
     const trimmed = origin.trim().toLowerCase();
-    return /^localhost(?::\d+)?$/.test(trimmed) || /^127\.0\.0\.1(?::\d+)?$/.test(trimmed);
+    return (
+      /^localhost(?::\d+)?$/.test(trimmed) ||
+      /^127\.0\.0\.1(?::\d+)?$/.test(trimmed) ||
+      /^0\.0\.0\.0(?::\d+)?$/.test(trimmed)
+    );
   }
 };
 
-const withoutLocalhostOrigins = (origins) =>
-  [...new Set(origins.filter((origin) => origin.length > 0 && !isLocalhostOrigin(origin)))];
+const withoutLocalhostOrigins = (origins) => [
+  ...new Set(origins.filter((origin) => origin.length > 0 && !isLocalhostOrigin(origin))),
+];
 
 export const parseAllowedOrigins = (raw) => {
   if (typeof raw !== "string") return [];

--- a/scripts/infra/parse-allowed-origins.mjs
+++ b/scripts/infra/parse-allowed-origins.mjs
@@ -1,7 +1,16 @@
 /**
  * Shared ALLOWED_ORIGINS parsing for Node smoke scripts.
- * Keep behavior aligned with supabase/functions/_shared/allowedOrigins.ts.
+ * Keep behavior aligned with supabase/functions/_shared/allowedOrigins.ts and
+ * scripts/infra/allowed-origins-fixtures.json (run npm run infra:check-allowed-origins).
  */
+
+const normalizeOrigin = (origin) => {
+  const trimmed = origin.trim();
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/\/+$/, "");
+  }
+  return trimmed;
+};
 
 export const parseAllowedOrigins = (raw) => {
   if (typeof raw !== "string") return [];
@@ -11,7 +20,7 @@ export const parseAllowedOrigins = (raw) => {
 
   const urlCandidates = normalized.match(/https?:\/\/[^",\s\]]+/g);
   if (urlCandidates && urlCandidates.length > 0) {
-    return [...new Set(urlCandidates.map((origin) => origin.trim()).filter(Boolean))];
+    return [...new Set(urlCandidates.map((origin) => normalizeOrigin(origin)).filter(Boolean))];
   }
 
   const domainCandidates = normalized.match(
@@ -22,7 +31,8 @@ export const parseAllowedOrigins = (raw) => {
       ...new Set(
         domainCandidates.map((domain) => {
           const host = domain.replace(/^\*\./, "");
-          return host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
+          const origin = host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
+          return normalizeOrigin(origin);
         }),
       ),
     ];
@@ -32,7 +42,7 @@ export const parseAllowedOrigins = (raw) => {
     ...new Set(
       normalized
         .split(",")
-        .map((origin) => origin.trim().replace(/^["'[]+|["'\]]+$/g, ""))
+        .map((origin) => normalizeOrigin(origin.trim().replace(/^["'[]+|["'\]]+$/g, "")))
         .filter(Boolean),
     ),
   ];
@@ -40,7 +50,7 @@ export const parseAllowedOrigins = (raw) => {
 
 export const resolveAllowedOrigin = (singleOrigin, originList) => {
   if (typeof singleOrigin === "string" && singleOrigin.trim().length > 0) {
-    return singleOrigin.trim();
+    return normalizeOrigin(singleOrigin);
   }
 
   const parsed = parseAllowedOrigins(originList ?? "");

--- a/scripts/infra/parse-allowed-origins.mjs
+++ b/scripts/infra/parse-allowed-origins.mjs
@@ -1,12 +1,16 @@
 /**
  * Shared ALLOWED_ORIGINS parsing for Node smoke scripts.
  *
- * Format rule (intentional security guardrail): full URLs and domain-only
- * shorthand are mutually exclusive in a single secret value. If any `http://` or
- * `https://` URL is present, only URL tokens are parsed — domain-only tokens
- * (e.g. `localhost:5173`) are dropped so prod secrets cannot accidentally pick
- * up localhost shorthand. For local dev, use a branch-only secret with full
- * origins (`http://localhost:5173`, …); see README → ALLOWED_ORIGINS.
+ * Security rules (always applied):
+ * - Localhost / loopback origins are never accepted (`localhost`, `127.0.0.1`,
+ *   `[::1]`). Every user runs a local server, so they are not a meaningful
+ *   origin boundary for edge-function CORS.
+ * - Full URLs and domain-only shorthand are mutually exclusive in one secret:
+ *   if any `http://` or `https://` URL is present, only URL tokens are parsed;
+ *   domain-only tokens in the same value are dropped.
+ *
+ * Local dev: test against a deployed preview origin (e.g. Pages dev URL), not
+ * localhost. See README → ALLOWED_ORIGINS.
  *
  * Keep behavior aligned with supabase/functions/_shared/allowedOrigins.ts and
  * scripts/infra/allowed-origins-fixtures.json (run npm run infra:check-allowed-origins).
@@ -20,6 +24,20 @@ const normalizeOrigin = (origin) => {
   return trimmed;
 };
 
+const isLocalhostOrigin = (origin) => {
+  try {
+    const { hostname } = new URL(origin);
+    const host = hostname.toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "[::1]" || host === "::1";
+  } catch {
+    const trimmed = origin.trim().toLowerCase();
+    return /^localhost(?::\d+)?$/.test(trimmed) || /^127\.0\.0\.1(?::\d+)?$/.test(trimmed);
+  }
+};
+
+const withoutLocalhostOrigins = (origins) =>
+  [...new Set(origins.filter((origin) => origin.length > 0 && !isLocalhostOrigin(origin)))];
+
 export const parseAllowedOrigins = (raw) => {
   if (typeof raw !== "string") return [];
 
@@ -28,37 +46,35 @@ export const parseAllowedOrigins = (raw) => {
 
   const urlCandidates = normalized.match(/https?:\/\/[^",\s\]]+/g);
   if (urlCandidates && urlCandidates.length > 0) {
-    return [...new Set(urlCandidates.map((origin) => normalizeOrigin(origin)).filter(Boolean))];
+    return withoutLocalhostOrigins(
+      urlCandidates.map((origin) => normalizeOrigin(origin)).filter(Boolean),
+    );
   }
 
   const domainCandidates = normalized.match(
-    /(?:\*\.)?(?:localhost|[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)(?::\d{2,5})?/g,
+    /(?:\*\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+(?::\d{2,5})?/g,
   );
   if (domainCandidates && domainCandidates.length > 0) {
-    return [
-      ...new Set(
-        domainCandidates.map((domain) => {
-          const host = domain.replace(/^\*\./, "");
-          const origin = host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
-          return normalizeOrigin(origin);
-        }),
-      ),
-    ];
+    return withoutLocalhostOrigins(
+      domainCandidates.map((domain) => {
+        const host = domain.replace(/^\*\./, "");
+        return normalizeOrigin(`https://${host}`);
+      }),
+    );
   }
 
-  return [
-    ...new Set(
-      normalized
-        .split(",")
-        .map((origin) => normalizeOrigin(origin.trim().replace(/^["'[]+|["'\]]+$/g, "")))
-        .filter(Boolean),
-    ),
-  ];
+  return withoutLocalhostOrigins(
+    normalized
+      .split(",")
+      .map((origin) => normalizeOrigin(origin.trim().replace(/^["'[]+|["'\]]+$/g, "")))
+      .filter(Boolean),
+  );
 };
 
 export const resolveAllowedOrigin = (singleOrigin, originList) => {
   if (typeof singleOrigin === "string" && singleOrigin.trim().length > 0) {
-    return normalizeOrigin(singleOrigin);
+    const normalized = normalizeOrigin(singleOrigin);
+    return isLocalhostOrigin(normalized) ? undefined : normalized;
   }
 
   const parsed = parseAllowedOrigins(originList ?? "");

--- a/scripts/infra/parse-allowed-origins.mjs
+++ b/scripts/infra/parse-allowed-origins.mjs
@@ -1,5 +1,13 @@
 /**
  * Shared ALLOWED_ORIGINS parsing for Node smoke scripts.
+ *
+ * Format rule (intentional security guardrail): full URLs and domain-only
+ * shorthand are mutually exclusive in a single secret value. If any `http://` or
+ * `https://` URL is present, only URL tokens are parsed — domain-only tokens
+ * (e.g. `localhost:5173`) are dropped so prod secrets cannot accidentally pick
+ * up localhost shorthand. For local dev, use a branch-only secret with full
+ * origins (`http://localhost:5173`, …); see README → ALLOWED_ORIGINS.
+ *
  * Keep behavior aligned with supabase/functions/_shared/allowedOrigins.ts and
  * scripts/infra/allowed-origins-fixtures.json (run npm run infra:check-allowed-origins).
  */

--- a/scripts/infra/parse-allowed-origins.mjs
+++ b/scripts/infra/parse-allowed-origins.mjs
@@ -32,7 +32,7 @@ export const parseAllowedOrigins = (raw) => {
     ...new Set(
       normalized
         .split(",")
-        .map((origin) => origin.trim().replace(/^["'\[]+|["'\]]+$/g, ""))
+        .map((origin) => origin.trim().replace(/^["'[]+|["'\]]+$/g, ""))
         .filter(Boolean),
     ),
   ];

--- a/scripts/infra/r2-cors.example.json
+++ b/scripts/infra/r2-cors.example.json
@@ -7,7 +7,7 @@
       "http://127.0.0.1:5173"
     ],
     "AllowedMethods": ["PUT", "GET", "HEAD"],
-    "AllowedHeaders": ["Content-Type", "Content-Length"],
+    "AllowedHeaders": ["content-type", "content-length"],
     "ExposeHeaders": ["ETag"],
     "MaxAgeSeconds": 3600
   }

--- a/scripts/infra/r2-cors.example.json
+++ b/scripts/infra/r2-cors.example.json
@@ -1,9 +1,6 @@
 [
   {
-    "AllowedOrigins": [
-      "https://your-project.pages.dev",
-      "https://yourdomain.com"
-    ],
+    "AllowedOrigins": ["https://your-project.pages.dev", "https://yourdomain.com"],
     "AllowedMethods": ["PUT", "GET", "HEAD"],
     "AllowedHeaders": ["content-type", "content-length"],
     "ExposeHeaders": ["ETag"],

--- a/scripts/infra/r2-cors.example.json
+++ b/scripts/infra/r2-cors.example.json
@@ -2,9 +2,7 @@
   {
     "AllowedOrigins": [
       "https://your-project.pages.dev",
-      "https://yourdomain.com",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173"
+      "https://yourdomain.com"
     ],
     "AllowedMethods": ["PUT", "GET", "HEAD"],
     "AllowedHeaders": ["content-type", "content-length"],

--- a/scripts/infra/resolve-smoke-allowed-origin.mjs
+++ b/scripts/infra/resolve-smoke-allowed-origin.mjs
@@ -18,4 +18,4 @@ if (!resolved) {
   process.exit(1);
 }
 
-console.log(resolved);
+process.stdout.write(`${resolved}\n`);

--- a/scripts/infra/resolve-smoke-allowed-origin.mjs
+++ b/scripts/infra/resolve-smoke-allowed-origin.mjs
@@ -1,0 +1,21 @@
+/*
+ * Resolve the Origin header for security smoke tests.
+ * Loopback origins are never returned — see parse-allowed-origins.mjs.
+ *
+ * Usage (CI or local):
+ *   ALLOWED_ORIGIN=... ALLOWED_ORIGINS=... node scripts/infra/resolve-smoke-allowed-origin.mjs
+ */
+
+import { resolveAllowedOrigin } from "./parse-allowed-origins.mjs";
+
+const resolved = resolveAllowedOrigin(process.env.ALLOWED_ORIGIN, process.env.ALLOWED_ORIGINS);
+
+if (!resolved) {
+  console.error(
+    "No deployable origin resolved from ALLOWED_ORIGIN/ALLOWED_ORIGINS. " +
+      "Loopback origins are rejected — use a deployed preview or production URL.",
+  );
+  process.exit(1);
+}
+
+console.log(resolved);

--- a/scripts/security/github-project-seed-smoke.mjs
+++ b/scripts/security/github-project-seed-smoke.mjs
@@ -15,6 +15,7 @@
 import { randomUUID } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
 import { requireSupabaseEnv } from "../infra/load-supabase-env.mjs";
+import { resolveAllowedOrigin } from "../infra/parse-allowed-origins.mjs";
 
 const GITHUB_SEED_URL = process.env.GITHUB_SEED_URL;
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN;
@@ -39,38 +40,6 @@ if (missing.length > 0) {
   console.error(`Missing required env vars: ${missing.join(", ")}`);
   process.exit(1);
 }
-
-const resolveAllowedOrigin = (singleOrigin, originList) => {
-  if (typeof singleOrigin === "string" && singleOrigin.trim().length > 0) {
-    return singleOrigin.trim();
-  }
-
-  if (typeof originList !== "string" || originList.trim().length === 0) {
-    return undefined;
-  }
-
-  const normalizedList = originList.replace(/\\\//g, "/");
-
-  const urlCandidates = normalizedList.match(/https?:\/\/[^",\s\]]+/g);
-  if (urlCandidates && urlCandidates.length > 0) {
-    return urlCandidates[0];
-  }
-
-  const domainCandidates = normalizedList.match(
-    /(?:\*\.)?(?:localhost|[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)(?::\d{2,5})?/g,
-  );
-
-  if (!domainCandidates || domainCandidates.length === 0) {
-    return undefined;
-  }
-
-  const firstDomain = domainCandidates[0].replace(/^\*\./, "");
-  if (firstDomain.startsWith("localhost")) {
-    return `http://${firstDomain}`;
-  }
-
-  return `https://${firstDomain}`;
-};
 
 const resolvedAllowedOrigin = resolveAllowedOrigin(ALLOWED_ORIGIN, ALLOWED_ORIGINS);
 
@@ -202,7 +171,7 @@ const run = async () => {
       {
         name: "returns metadata for valid admin request",
         method: "POST",
-        expectedStatus: [200, 403],
+        expectedStatus: resolvedAllowedOrigin ? 200 : [200, 403],
         headers: { ...headersBase, Authorization: `Bearer ${adminJwt}` },
         body: { repoUrl: GITHUB_SEED_TEST_REPO_URL },
       },

--- a/scripts/security/github-project-seed-smoke.mjs
+++ b/scripts/security/github-project-seed-smoke.mjs
@@ -44,9 +44,11 @@ if (missing.length > 0) {
 const resolvedAllowedOrigin = resolveAllowedOrigin(ALLOWED_ORIGIN, ALLOWED_ORIGINS);
 
 if (!resolvedAllowedOrigin) {
-  console.warn(
-    "No ALLOWED_ORIGIN value could be resolved from ALLOWED_ORIGIN/ALLOWED_ORIGINS; running without Origin header for non-negative checks.",
+  console.error(
+    "No ALLOWED_ORIGIN could be resolved from ALLOWED_ORIGIN/ALLOWED_ORIGINS. " +
+      "Loopback origins are rejected — set a deployed preview or production URL.",
   );
+  process.exit(1);
 }
 
 const headersBase = {
@@ -171,7 +173,7 @@ const run = async () => {
       {
         name: "returns metadata for valid admin request",
         method: "POST",
-        expectedStatus: resolvedAllowedOrigin ? 200 : [200, 403],
+        expectedStatus: 200,
         headers: { ...headersBase, Authorization: `Bearer ${adminJwt}` },
         body: { repoUrl: GITHUB_SEED_TEST_REPO_URL },
       },

--- a/scripts/security/r2-presign-smoke.mjs
+++ b/scripts/security/r2-presign-smoke.mjs
@@ -12,6 +12,7 @@
 import { randomUUID } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
 import { requireSupabaseEnv } from "../infra/load-supabase-env.mjs";
+import { resolveAllowedOrigin } from "../infra/parse-allowed-origins.mjs";
 
 const PRESIGN_URL = process.env.PRESIGN_URL;
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN;
@@ -34,38 +35,6 @@ if (missing.length > 0) {
   console.error(`Missing required env vars: ${missing.join(", ")}`);
   process.exit(1);
 }
-
-const resolveAllowedOrigin = (singleOrigin, originList) => {
-  if (typeof singleOrigin === "string" && singleOrigin.trim().length > 0) {
-    return singleOrigin.trim();
-  }
-
-  if (typeof originList !== "string" || originList.trim().length === 0) {
-    return undefined;
-  }
-
-  const normalizedList = originList.replace(/\\\//g, "/");
-
-  const urlCandidates = normalizedList.match(/https?:\/\/[^",\s\]]+/g);
-  if (urlCandidates && urlCandidates.length > 0) {
-    return urlCandidates[0];
-  }
-
-  const domainCandidates = normalizedList.match(
-    /(?:\*\.)?(?:localhost|[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)(?::\d{2,5})?/g,
-  );
-
-  if (!domainCandidates || domainCandidates.length === 0) {
-    return undefined;
-  }
-
-  const firstDomain = domainCandidates[0].replace(/^\*\./, "");
-  if (firstDomain.startsWith("localhost")) {
-    return `http://${firstDomain}`;
-  }
-
-  return `https://${firstDomain}`;
-};
 
 const resolvedAllowedOrigin = resolveAllowedOrigin(ALLOWED_ORIGIN, ALLOWED_ORIGINS);
 
@@ -202,7 +171,7 @@ const buildPostTests = ({ adminJwt, userJwt }) => [
   },
   {
     name: "allows admin request with valid payload",
-    expectedStatus: [200, 403],
+    expectedStatus: resolvedAllowedOrigin ? 200 : [200, 403],
     headers: { ...headersBase, Authorization: `Bearer ${adminJwt}` },
     body: {
       contentType: "video/mp4",

--- a/scripts/security/r2-presign-smoke.mjs
+++ b/scripts/security/r2-presign-smoke.mjs
@@ -39,9 +39,11 @@ if (missing.length > 0) {
 const resolvedAllowedOrigin = resolveAllowedOrigin(ALLOWED_ORIGIN, ALLOWED_ORIGINS);
 
 if (!resolvedAllowedOrigin) {
-  console.warn(
-    "No ALLOWED_ORIGIN value could be resolved from ALLOWED_ORIGIN/ALLOWED_ORIGINS; running without Origin header for non-negative checks.",
+  console.error(
+    "No ALLOWED_ORIGIN could be resolved from ALLOWED_ORIGIN/ALLOWED_ORIGINS. " +
+      "Loopback origins are rejected — set a deployed preview or production URL.",
   );
+  process.exit(1);
 }
 
 const headersBase = {
@@ -171,7 +173,7 @@ const buildPostTests = ({ adminJwt, userJwt }) => [
   },
   {
     name: "allows admin request with valid payload",
-    expectedStatus: resolvedAllowedOrigin ? 200 : [200, 403],
+    expectedStatus: 200,
     headers: { ...headersBase, Authorization: `Bearer ${adminJwt}` },
     body: {
       contentType: "video/mp4",

--- a/src/lib/github/fetchRepoSeed.ts
+++ b/src/lib/github/fetchRepoSeed.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { supabase } from "../supabase";
+import { getEdgeFunctionAuthHeaders, supabase } from "../supabase";
 
 const getGitHubSeedFunctionUrl = (): string => {
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
@@ -75,10 +75,7 @@ export const fetchGitHubProjectSeed = async (
   try {
     response = await fetch(githubSeedFunctionUrl, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${session.access_token}`,
-      },
+      headers: getEdgeFunctionAuthHeaders(session.access_token),
       body: JSON.stringify({ repoUrl }),
       signal: abortController.signal,
     });

--- a/src/lib/github/fetchRepoSeed.ts
+++ b/src/lib/github/fetchRepoSeed.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { getEdgeFunctionAuthHeaders, supabase } from "../supabase";
+import {
+  getEdgeFunctionAuthHeaders,
+  resolveEdgeFunctionErrorMessage,
+  supabase,
+} from "../supabase";
 
 const getGitHubSeedFunctionUrl = (): string => {
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
@@ -97,13 +101,11 @@ export const fetchGitHubProjectSeed = async (
   }
 
   if (!response.ok) {
-    const message =
-      response.status === 403 &&
-      (typeof responseBody !== "object" || responseBody === null || !("error" in responseBody))
-        ? `Request blocked (403). Ensure the Supabase ALLOWED_ORIGINS secret includes ${window.location.origin}.`
-        : typeof responseBody === "object" && responseBody !== null && "error" in responseBody
-          ? String((responseBody as Record<string, unknown>).error)
-          : "Failed to import repository data.";
+    const message = resolveEdgeFunctionErrorMessage(
+      response.status,
+      responseBody,
+      "Failed to import repository data.",
+    );
 
     throw new Error(message);
   }

--- a/src/lib/github/fetchRepoSeed.ts
+++ b/src/lib/github/fetchRepoSeed.ts
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {
-  getEdgeFunctionAuthHeaders,
-  resolveEdgeFunctionErrorMessage,
-  supabase,
-} from "../supabase";
+import { getEdgeFunctionAuthHeaders, resolveEdgeFunctionErrorMessage, supabase } from "../supabase";
 
 const getGitHubSeedFunctionUrl = (): string => {
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;

--- a/src/lib/github/fetchRepoSeed.ts
+++ b/src/lib/github/fetchRepoSeed.ts
@@ -98,9 +98,12 @@ export const fetchGitHubProjectSeed = async (
 
   if (!response.ok) {
     const message =
-      typeof responseBody === "object" && responseBody !== null && "error" in responseBody
-        ? String((responseBody as Record<string, unknown>).error)
-        : "Failed to import repository data.";
+      response.status === 403 &&
+      (typeof responseBody !== "object" || responseBody === null || !("error" in responseBody))
+        ? `Request blocked (403). Ensure the Supabase ALLOWED_ORIGINS secret includes ${window.location.origin}.`
+        : typeof responseBody === "object" && responseBody !== null && "error" in responseBody
+          ? String((responseBody as Record<string, unknown>).error)
+          : "Failed to import repository data.";
 
     throw new Error(message);
   }

--- a/src/lib/storage/r2client.ts
+++ b/src/lib/storage/r2client.ts
@@ -9,7 +9,7 @@
 // used exclusively inside the `r2-presign` edge function. The browser only
 // ever receives a short-lived presigned PUT URL, never the actual keys.
 
-import { getEdgeFunctionAuthHeaders, supabase } from "../supabase";
+import { getEdgeFunctionAuthHeaders, resolveEdgeFunctionErrorMessage, supabase } from "../supabase";
 import {
   R2_ALLOWED_FOLDERS,
   R2_UPLOAD_FOLDERS,
@@ -83,12 +83,11 @@ const requestPresignedUpload = async (
       /* intentional — body may be empty on error responses */
     }
 
-    const msg =
-      presignRes.status === 403 && (typeof body !== "object" || body === null || !("error" in body))
-        ? `Request blocked (403). Ensure the Supabase ALLOWED_ORIGINS secret includes ${typeof window !== "undefined" ? window.location.origin : "your site origin"}.`
-        : typeof body === "object" && body !== null && "error" in body
-          ? String((body as Record<string, unknown>).error)
-          : presignRes.statusText;
+    const msg = resolveEdgeFunctionErrorMessage(
+      presignRes.status,
+      body,
+      presignRes.statusText,
+    );
     throw new Error(`Failed to get presigned URL: ${msg}`);
   }
 
@@ -249,13 +248,11 @@ export const deleteFromR2 = async (publicUrl: string): Promise<void> => {
       /* intentional — body may be empty on error responses */
     }
 
-    const message =
-      deleteResponse.status === 403 &&
-      (typeof responseBody !== "object" || responseBody === null || !("error" in responseBody))
-        ? `Request blocked (403). Ensure the Supabase ALLOWED_ORIGINS secret includes ${typeof window !== "undefined" ? window.location.origin : "your site origin"}.`
-        : typeof responseBody === "object" && responseBody !== null && "error" in responseBody
-          ? String((responseBody as Record<string, unknown>).error)
-          : deleteResponse.statusText;
+    const message = resolveEdgeFunctionErrorMessage(
+      deleteResponse.status,
+      responseBody,
+      deleteResponse.statusText,
+    );
 
     throw new Error(`Failed to delete R2 object: ${message}`);
   }

--- a/src/lib/storage/r2client.ts
+++ b/src/lib/storage/r2client.ts
@@ -84,8 +84,7 @@ const requestPresignedUpload = async (
     }
 
     const msg =
-      presignRes.status === 403 &&
-      (typeof body !== "object" || body === null || !("error" in body))
+      presignRes.status === 403 && (typeof body !== "object" || body === null || !("error" in body))
         ? `Request blocked (403). Ensure the Supabase ALLOWED_ORIGINS secret includes ${typeof window !== "undefined" ? window.location.origin : "your site origin"}.`
         : typeof body === "object" && body !== null && "error" in body
           ? String((body as Record<string, unknown>).error)
@@ -108,7 +107,10 @@ const requestPresignedUpload = async (
   };
 };
 
-const buildPresignedPutHeaders = (signedUrl: string, contentType: string): Record<string, string> => {
+const buildPresignedPutHeaders = (
+  signedUrl: string,
+  contentType: string,
+): Record<string, string> => {
   const signedHeadersParam = new URL(signedUrl).searchParams.get("X-Amz-SignedHeaders");
   if (!signedHeadersParam) {
     return { "Content-Type": contentType };
@@ -148,8 +150,7 @@ const uploadToPresignedUrl = async (
       error instanceof Error
         ? error.message
         : "Unknown browser network error while uploading to R2.";
-    const siteOrigin =
-      typeof window !== "undefined" ? window.location.origin : "your site origin";
+    const siteOrigin = typeof window !== "undefined" ? window.location.origin : "your site origin";
     throw new Error(
       `Upload to R2 blocked (${uploadHost}). Presign succeeded; the browser PUT failed (${message}). Configure CORS on the R2 bucket matching R2_BUCKET_NAME: AllowedOrigins must include ${siteOrigin}; AllowedHeaders must include content-type (lowercase, not "*"). Run npm run infra:apply-r2-cors or Cloudflare Dashboard → R2 → bucket → Settings → CORS.`,
     );

--- a/src/lib/storage/r2client.ts
+++ b/src/lib/storage/r2client.ts
@@ -83,11 +83,7 @@ const requestPresignedUpload = async (
       /* intentional — body may be empty on error responses */
     }
 
-    const msg = resolveEdgeFunctionErrorMessage(
-      presignRes.status,
-      body,
-      presignRes.statusText,
-    );
+    const msg = resolveEdgeFunctionErrorMessage(presignRes.status, body, presignRes.statusText);
     throw new Error(`Failed to get presigned URL: ${msg}`);
   }
 

--- a/src/lib/storage/r2client.ts
+++ b/src/lib/storage/r2client.ts
@@ -250,9 +250,12 @@ export const deleteFromR2 = async (publicUrl: string): Promise<void> => {
     }
 
     const message =
-      typeof responseBody === "object" && responseBody !== null && "error" in responseBody
-        ? String((responseBody as Record<string, unknown>).error)
-        : deleteResponse.statusText;
+      deleteResponse.status === 403 &&
+      (typeof responseBody !== "object" || responseBody === null || !("error" in responseBody))
+        ? `Request blocked (403). Ensure the Supabase ALLOWED_ORIGINS secret includes ${typeof window !== "undefined" ? window.location.origin : "your site origin"}.`
+        : typeof responseBody === "object" && responseBody !== null && "error" in responseBody
+          ? String((responseBody as Record<string, unknown>).error)
+          : deleteResponse.statusText;
 
     throw new Error(`Failed to delete R2 object: ${message}`);
   }

--- a/src/lib/storage/r2client.ts
+++ b/src/lib/storage/r2client.ts
@@ -9,7 +9,7 @@
 // used exclusively inside the `r2-presign` edge function. The browser only
 // ever receives a short-lived presigned PUT URL, never the actual keys.
 
-import { supabase } from "../supabase";
+import { getEdgeFunctionAuthHeaders, supabase } from "../supabase";
 import {
   R2_ALLOWED_FOLDERS,
   R2_UPLOAD_FOLDERS,
@@ -57,10 +57,7 @@ const requestPresignedUpload = async (
   try {
     presignRes = await fetch(PRESIGN_FUNCTION_URL, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
+      headers: getEdgeFunctionAuthHeaders(accessToken),
       body: JSON.stringify({
         contentType,
         contentLength: file.size,
@@ -87,9 +84,12 @@ const requestPresignedUpload = async (
     }
 
     const msg =
-      typeof body === "object" && body !== null && "error" in body
-        ? String((body as Record<string, unknown>).error)
-        : presignRes.statusText;
+      presignRes.status === 403 &&
+      (typeof body !== "object" || body === null || !("error" in body))
+        ? `Request blocked (403). Ensure the Supabase ALLOWED_ORIGINS secret includes ${typeof window !== "undefined" ? window.location.origin : "your site origin"}.`
+        : typeof body === "object" && body !== null && "error" in body
+          ? String((body as Record<string, unknown>).error)
+          : presignRes.statusText;
     throw new Error(`Failed to get presigned URL: ${msg}`);
   }
 
@@ -108,6 +108,27 @@ const requestPresignedUpload = async (
   };
 };
 
+const buildPresignedPutHeaders = (signedUrl: string, contentType: string): Record<string, string> => {
+  const signedHeadersParam = new URL(signedUrl).searchParams.get("X-Amz-SignedHeaders");
+  if (!signedHeadersParam) {
+    return { "Content-Type": contentType };
+  }
+
+  const signed = new Set(
+    signedHeadersParam
+      .split(";")
+      .map((header) => header.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  const headers: Record<string, string> = {};
+  if (signed.has("content-type")) {
+    headers["Content-Type"] = contentType;
+  }
+
+  return headers;
+};
+
 const uploadToPresignedUrl = async (
   file: File,
   signedUrl: string,
@@ -120,15 +141,17 @@ const uploadToPresignedUrl = async (
     uploadRes = await fetch(signedUrl, {
       method: "PUT",
       body: file,
-      headers: { "Content-Type": contentType },
+      headers: buildPresignedPutHeaders(signedUrl, contentType),
     });
   } catch (error) {
     const message =
       error instanceof Error
         ? error.message
         : "Unknown browser network error while uploading to R2.";
+    const siteOrigin =
+      typeof window !== "undefined" ? window.location.origin : "your site origin";
     throw new Error(
-      `Upload to R2 blocked (${uploadHost}). Check R2 bucket CORS on the same bucket as R2_BUCKET_NAME: AllowedOrigins must include ${typeof window !== "undefined" ? window.location.origin : "your site origin"}, and AllowedHeaders must include Content-Type (the same header sent on PUT in r2client.ts). See README → R2 bucket CORS. ${message}`,
+      `Upload to R2 blocked (${uploadHost}). Presign succeeded; the browser PUT failed (${message}). Configure CORS on the R2 bucket matching R2_BUCKET_NAME: AllowedOrigins must include ${siteOrigin}; AllowedHeaders must include content-type (lowercase, not "*"). Run npm run infra:apply-r2-cors or Cloudflare Dashboard → R2 → bucket → Settings → CORS.`,
     );
   }
 
@@ -209,10 +232,7 @@ export const deleteFromR2 = async (publicUrl: string): Promise<void> => {
   try {
     deleteResponse = await fetch(PRESIGN_FUNCTION_URL, {
       method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
+      headers: getEdgeFunctionAuthHeaders(accessToken),
       body: JSON.stringify({ publicUrl: parsedPublicUrl.href }),
     });
   } catch (error) {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -243,6 +243,33 @@ export const getEdgeFunctionAuthHeaders = (accessToken: string): Record<string, 
   };
 };
 
+const getSiteOriginForDiagnostics = (): string =>
+  typeof window !== "undefined" ? window.location.origin : "your site origin";
+
+/** Actionable message when an edge function returns a bare 403 (CORS origin rejected). */
+export const getEdgeFunctionCorsBlockedMessage = (
+  origin: string = getSiteOriginForDiagnostics(),
+): string =>
+  `Request blocked (403). Ensure the Supabase ALLOWED_ORIGINS secret includes ${origin}.`;
+
+/** Prefer server JSON error body; surface CORS hint on bare 403 responses. */
+export const resolveEdgeFunctionErrorMessage = (
+  status: number,
+  body: unknown,
+  fallback: string,
+  origin?: string,
+): string => {
+  if (status === 403 && (typeof body !== "object" || body === null || !("error" in body))) {
+    return getEdgeFunctionCorsBlockedMessage(origin);
+  }
+
+  if (typeof body === "object" && body !== null && "error" in body) {
+    return String((body as Record<string, unknown>).error);
+  }
+
+  return fallback;
+};
+
 // For backward compatibility, export a proxy that throws on first use if not configured
 export const supabase = new Proxy({} as TypedClient, {
   get: (_, prop) => {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -228,6 +228,21 @@ export const getSupabaseClient = (): TypedClient => {
   return supabaseClient;
 };
 
+/** Headers required for direct browser fetch() calls to Supabase Edge Functions. */
+export const getEdgeFunctionAuthHeaders = (accessToken: string): Record<string, string> => {
+  if (!supabaseAnonKey) {
+    throw new Error(
+      "Supabase is not configured. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.",
+    );
+  }
+
+  return {
+    "Content-Type": "application/json",
+    apikey: supabaseAnonKey,
+    Authorization: `Bearer ${accessToken}`,
+  };
+};
+
 // For backward compatibility, export a proxy that throws on first use if not configured
 export const supabase = new Proxy({} as TypedClient, {
   get: (_, prop) => {

--- a/supabase/functions/_shared/allowedOrigins.ts
+++ b/supabase/functions/_shared/allowedOrigins.ts
@@ -1,0 +1,35 @@
+/**
+ * Parse ALLOWED_ORIGINS secret values into a normalized origin set.
+ *
+ * Supports comma-separated lists and JSON-like arrays copied from dashboards,
+ * e.g. `https://a.pages.dev,https://b.pages.dev` or
+ * `["https://a.pages.dev","https://b.pages.dev"]`.
+ */
+export function parseAllowedOrigins(raw: string): Set<string> {
+  const normalized = raw.trim().replace(/\\\//g, "/");
+  if (!normalized) return new Set();
+
+  const urlCandidates = normalized.match(/https?:\/\/[^",\s\]]+/g);
+  if (urlCandidates && urlCandidates.length > 0) {
+    return new Set(urlCandidates.map((origin) => origin.trim()).filter(Boolean));
+  }
+
+  const domainCandidates = normalized.match(
+    /(?:\*\.)?(?:localhost|[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)(?::\d{2,5})?/g,
+  );
+  if (domainCandidates && domainCandidates.length > 0) {
+    return new Set(
+      domainCandidates.map((domain) => {
+        const host = domain.replace(/^\*\./, "");
+        return host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
+      }),
+    );
+  }
+
+  return new Set(
+    normalized
+      .split(",")
+      .map((origin) => origin.trim().replace(/^["'\[]+|["'\]]+$/g, ""))
+      .filter(Boolean),
+  );
+}

--- a/supabase/functions/_shared/allowedOrigins.ts
+++ b/supabase/functions/_shared/allowedOrigins.ts
@@ -4,14 +4,27 @@
  * Supports comma-separated lists and JSON-like arrays copied from dashboards,
  * e.g. `https://a.pages.dev,https://b.pages.dev` or
  * `["https://a.pages.dev","https://b.pages.dev"]`.
+ *
+ * Keep behavior aligned with scripts/infra/parse-allowed-origins.mjs and
+ * scripts/infra/allowed-origins-fixtures.json (run npm run infra:check-allowed-origins).
  */
+const normalizeOrigin = (origin: string): string => {
+  const trimmed = origin.trim();
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/\/+$/, "");
+  }
+  return trimmed;
+};
+
 export function parseAllowedOrigins(raw: string): Set<string> {
   const normalized = raw.trim().replace(/\\\//g, "/");
   if (!normalized) return new Set();
 
   const urlCandidates = normalized.match(/https?:\/\/[^",\s\]]+/g);
   if (urlCandidates && urlCandidates.length > 0) {
-    return new Set(urlCandidates.map((origin) => origin.trim()).filter(Boolean));
+    return new Set(
+      urlCandidates.map((origin) => normalizeOrigin(origin)).filter(Boolean),
+    );
   }
 
   const domainCandidates = normalized.match(
@@ -21,7 +34,8 @@ export function parseAllowedOrigins(raw: string): Set<string> {
     return new Set(
       domainCandidates.map((domain) => {
         const host = domain.replace(/^\*\./, "");
-        return host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
+        const origin = host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
+        return normalizeOrigin(origin);
       }),
     );
   }
@@ -29,7 +43,7 @@ export function parseAllowedOrigins(raw: string): Set<string> {
   return new Set(
     normalized
       .split(",")
-      .map((origin) => origin.trim().replace(/^["'[]+|["'\]]+$/g, ""))
+      .map((origin) => normalizeOrigin(origin.trim().replace(/^["'[]+|["'\]]+$/g, "")))
       .filter(Boolean),
   );
 }

--- a/supabase/functions/_shared/allowedOrigins.ts
+++ b/supabase/functions/_shared/allowedOrigins.ts
@@ -6,7 +6,7 @@
  * `["https://a.pages.dev","https://b.pages.dev"]`.
  *
  * Security rules (always applied):
- * - Localhost / loopback origins are never accepted (`localhost`, `127.0.0.1`,
+ * - Localhost / loopback origins are never accepted (`localhost`, `127.0.0.1`, `0.0.0.0`,
  *   `[::1]`). Every user runs a local server, so they are not a meaningful
  *   origin boundary for edge-function CORS.
  * - Full URLs and domain-only shorthand are mutually exclusive in one secret:
@@ -31,10 +31,20 @@ const isLocalhostOrigin = (origin: string): boolean => {
   try {
     const { hostname } = new URL(origin);
     const host = hostname.toLowerCase();
-    return host === "localhost" || host === "127.0.0.1" || host === "[::1]" || host === "::1";
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "0.0.0.0" ||
+      host === "[::1]" ||
+      host === "::1"
+    );
   } catch {
     const trimmed = origin.trim().toLowerCase();
-    return /^localhost(?::\d+)?$/.test(trimmed) || /^127\.0\.0\.1(?::\d+)?$/.test(trimmed);
+    return (
+      /^localhost(?::\d+)?$/.test(trimmed) ||
+      /^127\.0\.0\.1(?::\d+)?$/.test(trimmed) ||
+      /^0\.0\.0\.0(?::\d+)?$/.test(trimmed)
+    );
   }
 };
 

--- a/supabase/functions/_shared/allowedOrigins.ts
+++ b/supabase/functions/_shared/allowedOrigins.ts
@@ -5,6 +5,13 @@
  * e.g. `https://a.pages.dev,https://b.pages.dev` or
  * `["https://a.pages.dev","https://b.pages.dev"]`.
  *
+ * Format rule (intentional security guardrail): full URLs and domain-only
+ * shorthand are mutually exclusive in a single secret value. If any `http://` or
+ * `https://` URL is present, only URL tokens are parsed — domain-only tokens
+ * (e.g. `localhost:5173`) are dropped so prod secrets cannot accidentally pick
+ * up localhost shorthand. For local dev, use a branch-only secret with full
+ * origins (`http://localhost:5173`, …); see README → ALLOWED_ORIGINS.
+ *
  * Keep behavior aligned with scripts/infra/parse-allowed-origins.mjs and
  * scripts/infra/allowed-origins-fixtures.json (run npm run infra:check-allowed-origins).
  */

--- a/supabase/functions/_shared/allowedOrigins.ts
+++ b/supabase/functions/_shared/allowedOrigins.ts
@@ -29,7 +29,7 @@ export function parseAllowedOrigins(raw: string): Set<string> {
   return new Set(
     normalized
       .split(",")
-      .map((origin) => origin.trim().replace(/^["'\[]+|["'\]]+$/g, ""))
+      .map((origin) => origin.trim().replace(/^["'[]+|["'\]]+$/g, ""))
       .filter(Boolean),
   );
 }

--- a/supabase/functions/_shared/allowedOrigins.ts
+++ b/supabase/functions/_shared/allowedOrigins.ts
@@ -5,12 +5,16 @@
  * e.g. `https://a.pages.dev,https://b.pages.dev` or
  * `["https://a.pages.dev","https://b.pages.dev"]`.
  *
- * Format rule (intentional security guardrail): full URLs and domain-only
- * shorthand are mutually exclusive in a single secret value. If any `http://` or
- * `https://` URL is present, only URL tokens are parsed — domain-only tokens
- * (e.g. `localhost:5173`) are dropped so prod secrets cannot accidentally pick
- * up localhost shorthand. For local dev, use a branch-only secret with full
- * origins (`http://localhost:5173`, …); see README → ALLOWED_ORIGINS.
+ * Security rules (always applied):
+ * - Localhost / loopback origins are never accepted (`localhost`, `127.0.0.1`,
+ *   `[::1]`). Every user runs a local server, so they are not a meaningful
+ *   origin boundary for edge-function CORS.
+ * - Full URLs and domain-only shorthand are mutually exclusive in one secret:
+ *   if any `http://` or `https://` URL is present, only URL tokens are parsed;
+ *   domain-only tokens in the same value are dropped.
+ *
+ * Local dev: test against a deployed preview origin (e.g. Pages dev URL), not
+ * localhost. See README → ALLOWED_ORIGINS.
  *
  * Keep behavior aligned with scripts/infra/parse-allowed-origins.mjs and
  * scripts/infra/allowed-origins-fixtures.json (run npm run infra:check-allowed-origins).
@@ -23,31 +27,44 @@ const normalizeOrigin = (origin: string): string => {
   return trimmed;
 };
 
+const isLocalhostOrigin = (origin: string): boolean => {
+  try {
+    const { hostname } = new URL(origin);
+    const host = hostname.toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "[::1]" || host === "::1";
+  } catch {
+    const trimmed = origin.trim().toLowerCase();
+    return /^localhost(?::\d+)?$/.test(trimmed) || /^127\.0\.0\.1(?::\d+)?$/.test(trimmed);
+  }
+};
+
+const withoutLocalhostOrigins = (origins: Iterable<string>): Set<string> =>
+  new Set([...origins].filter((origin) => origin.length > 0 && !isLocalhostOrigin(origin)));
+
 export function parseAllowedOrigins(raw: string): Set<string> {
   const normalized = raw.trim().replace(/\\\//g, "/");
   if (!normalized) return new Set();
 
   const urlCandidates = normalized.match(/https?:\/\/[^",\s\]]+/g);
   if (urlCandidates && urlCandidates.length > 0) {
-    return new Set(
+    return withoutLocalhostOrigins(
       urlCandidates.map((origin) => normalizeOrigin(origin)).filter(Boolean),
     );
   }
 
   const domainCandidates = normalized.match(
-    /(?:\*\.)?(?:localhost|[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)(?::\d{2,5})?/g,
+    /(?:\*\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+(?::\d{2,5})?/g,
   );
   if (domainCandidates && domainCandidates.length > 0) {
-    return new Set(
+    return withoutLocalhostOrigins(
       domainCandidates.map((domain) => {
         const host = domain.replace(/^\*\./, "");
-        const origin = host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
-        return normalizeOrigin(origin);
+        return normalizeOrigin(`https://${host}`);
       }),
     );
   }
 
-  return new Set(
+  return withoutLocalhostOrigins(
     normalized
       .split(",")
       .map((origin) => normalizeOrigin(origin.trim().replace(/^["'[]+|["'\]]+$/g, "")))

--- a/supabase/functions/_shared/r2Presign.ts
+++ b/supabase/functions/_shared/r2Presign.ts
@@ -1,0 +1,67 @@
+/*
+ * R2 S3 client tuned for browser PUT uploads via presigned URLs.
+ *
+ * AWS SDK v3 adds default CRC32 checksums that end up in the presigned URL
+ * (x-amz-checksum-crc32) but browsers cannot reproduce those headers, so PUTs
+ * fail with CORS/403 even when bucket CORS is correct.
+ */
+
+import { PutObjectCommand, S3Client } from "npm:@aws-sdk/client-s3@3.1026.0";
+import { getSignedUrl } from "npm:@aws-sdk/s3-request-presigner@3.1026.0";
+
+const CHECKSUM_HEADER_PREFIX = "x-amz-checksum-";
+
+export const createR2PresignClient = (
+  accountId: string,
+  accessKeyId: string,
+  secretAccessKey: string,
+): S3Client => {
+  const client = new S3Client({
+    region: "auto",
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId, secretAccessKey },
+    // Avoid automatic CRC32 checksum params in presigned URLs (browser-incompatible).
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    responseChecksumValidation: "WHEN_REQUIRED",
+  });
+
+  client.middlewareStack.add(
+    (next) => async (args) => {
+      const request = args.request as { headers?: Record<string, string> };
+      const headers = request.headers;
+      if (headers) {
+        for (const key of Object.keys(headers)) {
+          const lower = key.toLowerCase();
+          if (lower.startsWith(CHECKSUM_HEADER_PREFIX) || lower === "x-amz-sdk-checksum-algorithm") {
+            delete headers[key];
+          }
+        }
+      }
+      return next(args);
+    },
+    { step: "build", name: "stripChecksumHeadersForBrowserPresign" },
+  );
+
+  return client;
+};
+
+export const createBrowserPresignedPutUrl = async (input: {
+  client: S3Client;
+  bucket: string;
+  key: string;
+  contentType: string;
+  contentLength: number;
+  expiresInSeconds?: number;
+}): Promise<string> => {
+  const command = new PutObjectCommand({
+    Bucket: input.bucket,
+    Key: input.key,
+    ContentType: input.contentType,
+    ContentLength: input.contentLength,
+  });
+
+  return getSignedUrl(input.client, command, {
+    expiresIn: input.expiresInSeconds ?? 900,
+    signableHeaders: new Set(["content-type"]),
+  });
+};

--- a/supabase/functions/github-project-seed/index.ts
+++ b/supabase/functions/github-project-seed/index.ts
@@ -5,14 +5,10 @@
  */
 
 import { createClient } from "npm:@supabase/supabase-js@2.102.1";
+import { parseAllowedOrigins } from "../_shared/allowedOrigins.ts";
 
 const rawOrigins = Deno.env.get("ALLOWED_ORIGINS") ?? "";
-const ALLOWED_ORIGINS = new Set(
-  rawOrigins
-    .split(",")
-    .map((origin: string) => origin.trim())
-    .filter(Boolean),
-);
+const ALLOWED_ORIGINS = parseAllowedOrigins(rawOrigins);
 const HAS_ALLOWED_ORIGINS = ALLOWED_ORIGINS.size > 0;
 
 interface RepoSeedBody {

--- a/supabase/functions/r2-presign/index.ts
+++ b/supabase/functions/r2-presign/index.ts
@@ -15,21 +15,17 @@
 //                      e.g. "https://abc.pages.dev,https://yourdomain.com"
 //   LOG_LEVEL        — optional: debug | info | warn | error (default: info)
 
-import { DeleteObjectCommand, PutObjectCommand, S3Client } from "npm:@aws-sdk/client-s3@3.1026.0";
-import { getSignedUrl } from "npm:@aws-sdk/s3-request-presigner@3.1026.0";
+import { DeleteObjectCommand } from "npm:@aws-sdk/client-s3@3.1026.0";
 import { createClient } from "npm:@supabase/supabase-js@2.102.1";
+import { parseAllowedOrigins } from "../_shared/allowedOrigins.ts";
 import { createLogger } from "../_shared/logger.ts";
+import { createBrowserPresignedPutUrl, createR2PresignClient } from "../_shared/r2Presign.ts";
 
 // Allowed origins for CORS — configured per environment via the ALLOWED_ORIGINS secret.
 // Set it to a comma-separated list, e.g.:
 //   supabase secrets set ALLOWED_ORIGINS="https://abc.pages.dev,https://yourdomain.com"
 const rawOrigins = Deno.env.get("ALLOWED_ORIGINS") ?? "";
-const ALLOWED_ORIGINS = new Set(
-  rawOrigins
-    .split(",")
-    .map((o: string) => o.trim())
-    .filter(Boolean),
-);
+const ALLOWED_ORIGINS = parseAllowedOrigins(rawOrigins);
 const HAS_ALLOWED_ORIGINS = ALLOWED_ORIGINS.size > 0;
 
 const LOG_LEVEL = (Deno.env.get("LOG_LEVEL") ?? "info").trim().toLowerCase();
@@ -268,11 +264,7 @@ Deno.serve(async (req: Request) => {
 
     const ALLOWED_FOLDERS = Object.keys(FOLDER_POLICIES);
 
-    const r2 = new S3Client({
-      region: "auto",
-      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-      credentials: { accessKeyId, secretAccessKey },
-    });
+    const r2 = createR2PresignClient(accountId, accessKeyId, secretAccessKey);
 
     if (req.method === "DELETE") {
       if (
@@ -386,16 +378,13 @@ Deno.serve(async (req: Request) => {
     const ext = extNoDot.length > 0 ? `.${extNoDot}` : "";
     const key = `${folder}/${crypto.randomUUID()}${ext}`;
 
-    const command = new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      ContentType: normalizedContentType,
-      // Bind expected byte size into the signature so a different payload size is rejected.
-      ContentLength: contentLength,
+    const signedUrl = await createBrowserPresignedPutUrl({
+      client: r2,
+      bucket,
+      key,
+      contentType: normalizedContentType,
+      contentLength,
     });
-
-    // Presigned URL valid for 15 minutes — enough for a video upload
-    const signedUrl = await getSignedUrl(r2, command, { expiresIn: 900 });
 
     requestLogger.info("Presigned upload URL issued", {
       folder,


### PR DESCRIPTION
## Summary

- Fix browser R2 uploads by presigning PUT URLs without SDK CRC32 checksums (browser-incompatible) and signing only `content-type` for `fetch()` PUTs (`supabase/functions/_shared/r2Presign.ts`).
- Send `apikey` on direct edge-function calls from the admin client; centralize auth headers and CORS 403 diagnostics in `src/lib/supabase.ts`.
- Align presigned PUT headers with `X-Amz-SignedHeaders` in `src/lib/storage/r2client.ts`; improve R2 upload failure messages when bucket CORS is misconfigured.
- Unify `ALLOWED_ORIGINS` parsing across edge functions, smoke scripts, and R2 CORS tooling via shared `parseAllowedOrigins` (comma list, JSON-style arrays, domain shorthand).
- **Reject localhost / loopback origins everywhere** (`localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]`) — test uploads and edge functions from a **deployed preview origin**, not `npm run dev` against production secrets.
- Document the mixed-format guardrail: full URLs and domain-only shorthand are mutually exclusive in one secret.
- CI: add Deno + `npm run infra:check-allowed-origins` parity step; smoke workflows resolve origins through `scripts/infra/resolve-smoke-allowed-origin.mjs`.
- R2 bucket CORS infra: lowercase `content-type` / `content-length` headers, dashboard fallback when API token lacks CORS admin permission.
- Update README and Supabase skills to the preview-only `ALLOWED_ORIGINS` policy.

## Deploy / ops (after merge)

1. Deploy edge functions:
   ```bash
   npx supabase functions deploy r2-presign
   npx supabase functions deploy github-project-seed
   ```
2. Set `ALLOWED_ORIGINS` to your deployed site URL(s) only — **no localhost** (e.g. `https://dev.personal-website-5f5.pages.dev`, production domain).
3. Apply matching R2 bucket CORS (same origins as `ALLOWED_ORIGINS`):
   ```bash
   npm run infra:apply-r2-cors
   ```
   Or use Cloudflare Dashboard → R2 → bucket → Settings → CORS if the API token lacks CORS admin permission.

## Test plan

- [x] CI: lint, format, build
- [x] CI: allowed-origins parser parity (Node + Deno)
- [x] CI: CodeQL, Semgrep, Gitleaks, npm audit
- [ ] Deploy `r2-presign` and `github-project-seed` to Supabase
- [ ] Upload a video/image from admin on a Pages preview origin
- [ ] Confirm presigned URL has no `x-amz-checksum-crc32` and includes `content-type` in signed headers
- [ ] Confirm loopback origins are rejected when set in `ALLOWED_ORIGINS`
- [ ] Security smoke workflows pass against deployed functions (repo secrets configured)