### PR TITLE
Fix GameDev gallery UX and admin folder navigation

### DIFF
--- a/src/components/admin/mediaLibrary/FolderCard.tsx
+++ b/src/components/admin/mediaLibrary/FolderCard.tsx
@@ -6,7 +6,7 @@
 
 import { motion } from "framer-motion";
 import { Folder } from "lucide-react";
-import { type DragEvent, type MouseEvent, useEffect, useRef, useState } from "react";
+import { type DragEvent, type KeyboardEvent, type MouseEvent, useEffect, useRef, useState } from "react";
 import { playClickSound, playHoverSound } from "../../../lib/sound/interactionSounds";
 import type { TimeoutHandle } from "../../../types/handles";
 import type { FolderEntry } from "./types";
@@ -185,14 +185,26 @@ export const FolderCard = ({
         onClick={() => {
           playClickSound();
           triggerClickAnimation();
+        }}
+        onDoubleClick={() => {
+          playClickSound();
+          triggerClickAnimation();
           openFolder();
+        }}
+        onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            playClickSound();
+            triggerClickAnimation();
+            openFolder();
+          }
         }}
         className={`relative flex h-36 w-44 items-center justify-center overflow-hidden rounded-xl border text-left transition-all ${
           isDropActive
             ? "border-cyan-300/80 bg-cyan-400/15 shadow-[0_0_0_2px_rgba(103,232,249,0.45),0_0_26px_rgba(34,211,238,0.28)]"
             : "border-transparent hover:border-amber-300/30 hover:bg-amber-200/5"
         }`}
-        aria-label={`Open folder: ${entry.name}`}
+        aria-label={`Open folder: ${entry.name} (double-click)`}
       >
         <Folder
           className={`h-24 w-24 drop-shadow-[0_8px_14px_rgba(0,0,0,0.5)] ${

--- a/src/components/admin/mediaLibrary/FolderCard.tsx
+++ b/src/components/admin/mediaLibrary/FolderCard.tsx
@@ -211,7 +211,7 @@ export const FolderCard = ({
             ? "border-cyan-300/80 bg-cyan-400/15 shadow-[0_0_0_2px_rgba(103,232,249,0.45),0_0_26px_rgba(34,211,238,0.28)]"
             : "border-transparent hover:border-amber-300/30 hover:bg-amber-200/5"
         }`}
-        aria-label={`Open folder: ${entry.name} (double-click)`}
+        aria-label={`${entry.name}. Double-click or press Enter to open folder.`}
       >
         <Folder
           className={`h-24 w-24 drop-shadow-[0_8px_14px_rgba(0,0,0,0.5)] ${

--- a/src/components/admin/mediaLibrary/FolderCard.tsx
+++ b/src/components/admin/mediaLibrary/FolderCard.tsx
@@ -42,11 +42,15 @@ export const FolderCard = ({
   const [isClickAnimating, setIsClickAnimating] = useState(false);
   const dragDepthRef = useRef(0);
   const clickAnimationTimeoutRef = useRef<TimeoutHandle | null>(null);
+  const singleClickTimeoutRef = useRef<TimeoutHandle | null>(null);
 
   useEffect(() => {
     return () => {
       if (clickAnimationTimeoutRef.current !== null) {
         window.clearTimeout(clickAnimationTimeoutRef.current);
+      }
+      if (singleClickTimeoutRef.current !== null) {
+        window.clearTimeout(singleClickTimeoutRef.current);
       }
     };
   }, []);
@@ -109,6 +113,18 @@ export const FolderCard = ({
   const openFolder = () => {
     onNavigate(entry.path);
     onClearSearch();
+  };
+
+  const clearPendingSingleClick = () => {
+    if (singleClickTimeoutRef.current !== null) {
+      window.clearTimeout(singleClickTimeoutRef.current);
+      singleClickTimeoutRef.current = null;
+    }
+  };
+
+  const playClickFeedback = () => {
+    playClickSound();
+    triggerClickAnimation();
   };
 
   return (
@@ -190,19 +206,22 @@ export const FolderCard = ({
           onContextMenu(e);
         }}
         onClick={() => {
-          playClickSound();
-          triggerClickAnimation();
+          clearPendingSingleClick();
+          singleClickTimeoutRef.current = setTimeout(() => {
+            singleClickTimeoutRef.current = null;
+            playClickFeedback();
+          }, 250);
         }}
         onDoubleClick={() => {
-          playClickSound();
-          triggerClickAnimation();
+          clearPendingSingleClick();
+          playClickFeedback();
           openFolder();
         }}
         onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
           if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
-            playClickSound();
-            triggerClickAnimation();
+            clearPendingSingleClick();
+            playClickFeedback();
             openFolder();
           }
         }}

--- a/src/components/admin/mediaLibrary/FolderCard.tsx
+++ b/src/components/admin/mediaLibrary/FolderCard.tsx
@@ -6,7 +6,14 @@
 
 import { motion } from "framer-motion";
 import { Folder } from "lucide-react";
-import { type DragEvent, type KeyboardEvent, type MouseEvent, useEffect, useRef, useState } from "react";
+import {
+  type DragEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { playClickSound, playHoverSound } from "../../../lib/sound/interactionSounds";
 import type { TimeoutHandle } from "../../../types/handles";
 import type { FolderEntry } from "./types";

--- a/src/components/ui/common/cards/ProjectCardBase.tsx
+++ b/src/components/ui/common/cards/ProjectCardBase.tsx
@@ -83,7 +83,38 @@ export const ProjectCardBase = ({
     ? "h-auto min-h-0 overflow-visible pt-2"
     : "h-full min-h-0 overflow-visible pt-2";
 
-  const cardBody = (
+  const githubLinkClassName = compact
+    ? "text-gray-400 transition-colors hover:text-white"
+    : "text-gray-400 transition-colors hover:text-white";
+
+  const githubLinkOverlayClassName = compact
+    ? `absolute top-3 right-3 z-30 ${githubLinkClassName}`
+    : `absolute top-5 right-5 z-30 ${githubLinkClassName}`;
+
+  const renderGitHubLink = (className: string) => {
+    if (!link) return null;
+
+    return (
+      <motion.a
+        whileHover={{ scale: 1.15, rotate: 8 }}
+        whileTap={{ scale: 0.9 }}
+        onMouseEnter={playHoverSound}
+        onClick={(event) => {
+          event.stopPropagation();
+          playClickSound();
+        }}
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`View ${title} on GitHub`}
+        className={className}
+      >
+        <GitHubIcon className={compact ? "h-5 w-5" : "h-6 w-6"} />
+      </motion.a>
+    );
+  };
+
+  const cardBody = (showGitHubInHeader: boolean) => (
     <>
       {hasThumbnail && (
         <div
@@ -119,24 +150,7 @@ export const ProjectCardBase = ({
               </MotionLink>
             )}
 
-            {link && (
-              <motion.a
-                whileHover={{ scale: 1.15, rotate: 8 }}
-                whileTap={{ scale: 0.9 }}
-                onMouseEnter={playHoverSound}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  playClickSound();
-                }}
-                href={link}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`View ${title} on GitHub`}
-                className="relative z-30 text-gray-400 transition-colors hover:text-white"
-              >
-                <GitHubIcon className={compact ? "h-5 w-5" : "h-6 w-6"} />
-              </motion.a>
-            )}
+            {showGitHubInHeader && renderGitHubLink(`relative z-30 ${githubLinkClassName}`)}
           </div>
         </div>
 
@@ -170,34 +184,42 @@ export const ProjectCardBase = ({
     </>
   );
 
+  const motionProps = {
+    initial: { opacity: 0, y: 16 },
+    animate: isRevealed && isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 },
+    transition: { duration: 0.3, delay: isRevealed ? 0.1 + index * 0.07 : 0 },
+  };
+
   return (
     <div ref={ref} className={wrapperClassName}>
       {useDoubleClickOpen ? (
         <motion.div
-          role="button"
-          tabIndex={0}
-          title="Double-click to open project"
-          aria-label={`${title}. Double-click to open project page.`}
-          initial={{ opacity: 0, y: 16 }}
-          animate={isRevealed && isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
-          transition={{ duration: 0.3, delay: isRevealed ? 0.1 + index * 0.07 : 0 }}
-          whileHover={{ y: -6, transition: { duration: 0.12, ease: "easeOut" } }}
-          onMouseEnter={playHoverSound}
-          onDoubleClick={handleDoubleClick}
-          onKeyDown={handleKeyDown}
-          className={`relative cursor-pointer ${theme.containerClassName}`}
-        >
-          {cardBody}
-        </motion.div>
-      ) : (
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={isRevealed && isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
-          transition={{ duration: 0.3, delay: isRevealed ? 0.1 + index * 0.07 : 0 }}
+          {...motionProps}
           whileHover={{ y: -6, transition: { duration: 0.12, ease: "easeOut" } }}
           className={`relative ${theme.containerClassName}`}
         >
-          {cardBody}
+          <motion.div
+            role="button"
+            tabIndex={0}
+            title="Double-click to open project"
+            aria-label={`${title}. Double-click or press Enter to open project page.`}
+            whileTap={{ scale: 0.98 }}
+            onMouseEnter={playHoverSound}
+            onDoubleClick={handleDoubleClick}
+            onKeyDown={handleKeyDown}
+            className="relative h-full w-full cursor-pointer"
+          >
+            {cardBody(false)}
+          </motion.div>
+          {renderGitHubLink(githubLinkOverlayClassName)}
+        </motion.div>
+      ) : (
+        <motion.div
+          {...motionProps}
+          whileHover={{ y: -6, transition: { duration: 0.12, ease: "easeOut" } }}
+          className={`relative ${theme.containerClassName}`}
+        >
+          {cardBody(true)}
         </motion.div>
       )}
     </div>

--- a/src/components/ui/common/cards/ProjectCardBase.tsx
+++ b/src/components/ui/common/cards/ProjectCardBase.tsx
@@ -5,9 +5,9 @@
  */
 
 import { motion, useInView } from "framer-motion";
-import type { ReactNode } from "react";
-import { useContext, useRef } from "react";
-import { Link } from "react-router-dom";
+import type { KeyboardEvent, ReactNode } from "react";
+import { useCallback, useContext, useRef } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { playClickSound, playHoverSound } from "../../../../lib/sound/interactionSounds";
 import { GitHubIcon } from "../icons/BrandIcons";
 import { SectionRevealContext } from "../sections/sectionRevealContext";
@@ -30,6 +30,8 @@ interface ProjectCardBaseProps {
   icon: ReactNode;
   index: number;
   compact?: boolean;
+  contentSized?: boolean;
+  openOnDoubleClick?: boolean;
   thumbnailUrl?: string;
   theme: ProjectCardTheme;
 }
@@ -43,101 +45,163 @@ export const ProjectCardBase = ({
   icon,
   index,
   compact = false,
+  contentSized = false,
+  openOnDoubleClick = false,
   thumbnailUrl,
   theme,
 }: ProjectCardBaseProps) => {
   const isRevealed = useContext(SectionRevealContext);
   const ref = useRef<HTMLDivElement>(null);
   const isInView = useInView(ref, { once: true });
+  const navigate = useNavigate();
   const hasThumbnail = !!thumbnailUrl;
+  const useDoubleClickOpen = openOnDoubleClick && !!detailsLink;
 
-  return (
-    <div ref={ref} className="h-full min-h-0 overflow-visible pt-2">
-      <motion.div
-        initial={{ opacity: 0, y: 16 }}
-        animate={isRevealed && isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
-        transition={{ duration: 0.3, delay: isRevealed ? 0.1 + index * 0.07 : 0 }}
-        whileHover={{ y: -6, transition: { duration: 0.12, ease: "easeOut" } }}
-        className={`relative ${theme.containerClassName}`}
+  const openProjectPage = useCallback(() => {
+    if (!detailsLink) return;
+
+    playClickSound();
+    navigate(detailsLink);
+  }, [detailsLink, navigate]);
+
+  const handleDoubleClick = () => {
+    if (!useDoubleClickOpen) return;
+
+    openProjectPage();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!useDoubleClickOpen) return;
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openProjectPage();
+    }
+  };
+
+  const wrapperClassName = contentSized
+    ? "h-auto min-h-0 overflow-visible pt-2"
+    : "h-full min-h-0 overflow-visible pt-2";
+  const containerClassName = contentSized
+    ? theme.containerClassName.replace(/\bh-full\b/g, "h-auto").replace(/\boverflow-hidden\b/g, "overflow-visible")
+    : theme.containerClassName;
+
+  const cardBody = (
+    <>
+      {hasThumbnail && (
+        <div
+          className={`relative z-20 ${compact ? "h-20 xl:h-24" : "h-32 xl:h-36"} shrink-0 overflow-hidden`}
+        >
+          <img
+            src={thumbnailUrl}
+            alt={title}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        </div>
+      )}
+
+      <div
+        className={`relative z-20 flex min-h-0 flex-col ${compact ? "gap-2 p-3" : "gap-2.5 p-5"}`}
       >
-        {hasThumbnail && (
+        <div className="flex items-start justify-between gap-3">
+          <div className={`${theme.iconShellClassName} ${compact ? "p-2" : "p-2.5"}`}>{icon}</div>
+
+          <div className="flex items-center gap-2">
+            {detailsLink && !useDoubleClickOpen && (
+              <MotionLink
+                to={detailsLink}
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                onMouseEnter={playHoverSound}
+                onClick={playClickSound}
+                aria-label={`Open ${title} project page`}
+                className="relative z-30 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-cyan-200 transition-colors hover:border-cyan-400/40 hover:text-cyan-100"
+              >
+                Open
+              </MotionLink>
+            )}
+
+            {link && (
+              <motion.a
+                whileHover={{ scale: 1.15, rotate: 8 }}
+                whileTap={{ scale: 0.9 }}
+                onMouseEnter={playHoverSound}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  playClickSound();
+                }}
+                href={link}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`View ${title} on GitHub`}
+                className="relative z-30 text-gray-400 transition-colors hover:text-white"
+              >
+                <GitHubIcon className={compact ? "h-5 w-5" : "h-6 w-6"} />
+              </motion.a>
+            )}
+          </div>
+        </div>
+
+        <h3 className={`${theme.titleClassName} ${compact ? "text-sm" : "text-xl"}`}>{title}</h3>
+
+        <p
+          className={`min-h-0 leading-relaxed text-gray-400 ${
+            contentSized ? "flex-none" : "flex-grow"
+          } ${compact ? "line-clamp-2 text-xs" : contentSized ? "text-base" : "line-clamp-4 text-base"}`}
+        >
+          {description}
+        </p>
+
+        {tags && tags.length > 0 && (
           <div
-            className={`relative z-20 ${compact ? "h-20 xl:h-24" : "h-32 xl:h-36"} shrink-0 overflow-hidden`}
+            className={`${contentSized ? "" : "mt-auto"} flex flex-wrap ${compact ? "gap-1" : "gap-1.5"}`}
           >
-            <img
-              src={thumbnailUrl}
-              alt={title}
-              className="h-full w-full object-cover"
-              loading="lazy"
-            />
+            {tags.map((tag, tagIndex) => (
+              <span
+                key={tagIndex}
+                className={`${theme.tagClassName} ${
+                  compact ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-1 text-xs"
+                }`}
+              >
+                {tag}
+              </span>
+            ))}
           </div>
         )}
+      </div>
+    </>
+  );
 
-        <div
-          className={`relative z-20 flex min-h-0 flex-col ${compact ? "gap-2 p-3" : "gap-2.5 p-5"}`}
+  return (
+    <div ref={ref} className={wrapperClassName}>
+      {useDoubleClickOpen ? (
+        <motion.div
+          role="button"
+          tabIndex={0}
+          title="Double-click to open project"
+          aria-label={`${title}. Double-click to open project page.`}
+          initial={{ opacity: 0, y: 16 }}
+          animate={isRevealed && isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
+          transition={{ duration: 0.3, delay: isRevealed ? 0.1 + index * 0.07 : 0 }}
+          whileHover={{ y: -6, transition: { duration: 0.12, ease: "easeOut" } }}
+          onDoubleClick={handleDoubleClick}
+          onKeyDown={handleKeyDown}
+          className={`relative cursor-pointer ${containerClassName}`}
         >
-          <div className="flex items-start justify-between gap-3">
-            <div className={`${theme.iconShellClassName} ${compact ? "p-2" : "p-2.5"}`}>{icon}</div>
-
-            <div className="flex items-center gap-2">
-              {detailsLink && (
-                <MotionLink
-                  to={detailsLink}
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
-                  onMouseEnter={playHoverSound}
-                  onClick={playClickSound}
-                  aria-label={`Open ${title} project page`}
-                  className="relative z-30 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-cyan-200 transition-colors hover:border-cyan-400/40 hover:text-cyan-100"
-                >
-                  Open
-                </MotionLink>
-              )}
-
-              {link && (
-                <motion.a
-                  whileHover={{ scale: 1.15, rotate: 8 }}
-                  whileTap={{ scale: 0.9 }}
-                  onMouseEnter={playHoverSound}
-                  onClick={playClickSound}
-                  href={link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={`View ${title} on GitHub`}
-                  className="relative z-30 text-gray-400 transition-colors hover:text-white"
-                >
-                  <GitHubIcon className={compact ? "h-5 w-5" : "h-6 w-6"} />
-                </motion.a>
-              )}
-            </div>
-          </div>
-
-          <h3 className={`${theme.titleClassName} ${compact ? "text-sm" : "text-xl"}`}>{title}</h3>
-
-          <p
-            className={`min-h-0 flex-grow leading-relaxed text-gray-400 ${
-              compact ? "line-clamp-2 text-xs" : "line-clamp-4 text-base"
-            }`}
-          >
-            {description}
-          </p>
-
-          {tags && tags.length > 0 && (
-            <div className={`mt-auto flex flex-wrap ${compact ? "gap-1" : "gap-1.5"}`}>
-              {tags.map((tag, tagIndex) => (
-                <span
-                  key={tagIndex}
-                  className={`${theme.tagClassName} ${
-                    compact ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-1 text-xs"
-                  }`}
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
-      </motion.div>
+          {cardBody}
+        </motion.div>
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={isRevealed && isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
+          transition={{ duration: 0.3, delay: isRevealed ? 0.1 + index * 0.07 : 0 }}
+          whileHover={{ y: -6, transition: { duration: 0.12, ease: "easeOut" } }}
+          className={`relative ${containerClassName}`}
+        >
+          {cardBody}
+        </motion.div>
+      )}
     </div>
   );
 };

--- a/src/components/ui/common/cards/ProjectCardBase.tsx
+++ b/src/components/ui/common/cards/ProjectCardBase.tsx
@@ -82,9 +82,6 @@ export const ProjectCardBase = ({
   const wrapperClassName = contentSized
     ? "h-auto min-h-0 overflow-visible pt-2"
     : "h-full min-h-0 overflow-visible pt-2";
-  const containerClassName = contentSized
-    ? theme.containerClassName.replace(/\bh-full\b/g, "h-auto").replace(/\boverflow-hidden\b/g, "overflow-visible")
-    : theme.containerClassName;
 
   const cardBody = (
     <>
@@ -185,9 +182,10 @@ export const ProjectCardBase = ({
           animate={isRevealed && isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
           transition={{ duration: 0.3, delay: isRevealed ? 0.1 + index * 0.07 : 0 }}
           whileHover={{ y: -6, transition: { duration: 0.12, ease: "easeOut" } }}
+          onMouseEnter={playHoverSound}
           onDoubleClick={handleDoubleClick}
           onKeyDown={handleKeyDown}
-          className={`relative cursor-pointer ${containerClassName}`}
+          className={`relative cursor-pointer ${theme.containerClassName}`}
         >
           {cardBody}
         </motion.div>
@@ -197,7 +195,7 @@ export const ProjectCardBase = ({
           animate={isRevealed && isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 16 }}
           transition={{ duration: 0.3, delay: isRevealed ? 0.1 + index * 0.07 : 0 }}
           whileHover={{ y: -6, transition: { duration: 0.12, ease: "easeOut" } }}
-          className={`relative ${containerClassName}`}
+          className={`relative ${theme.containerClassName}`}
         >
           {cardBody}
         </motion.div>

--- a/src/components/ui/common/cards/ProjectCardBase.tsx
+++ b/src/components/ui/common/cards/ProjectCardBase.tsx
@@ -83,9 +83,7 @@ export const ProjectCardBase = ({
     ? "h-auto min-h-0 overflow-visible pt-2"
     : "h-full min-h-0 overflow-visible pt-2";
 
-  const githubLinkClassName = compact
-    ? "text-gray-400 transition-colors hover:text-white"
-    : "text-gray-400 transition-colors hover:text-white";
+  const githubLinkClassName = "text-gray-400 transition-colors hover:text-white";
 
   const githubLinkOverlayClassName = compact
     ? `absolute top-3 right-3 z-30 ${githubLinkClassName}`

--- a/src/components/ui/gamedev/common/cards/GameDevProjectCard.tsx
+++ b/src/components/ui/gamedev/common/cards/GameDevProjectCard.tsx
@@ -16,6 +16,8 @@ interface GameDevProjectCardProps {
   icon: ReactNode;
   index: number;
   compact?: boolean;
+  contentSized?: boolean;
+  openOnDoubleClick?: boolean;
   thumbnailUrl?: string;
 }
 
@@ -28,6 +30,8 @@ export const GameDevProjectCard = ({
   icon,
   index,
   compact = false,
+  contentSized = false,
+  openOnDoubleClick = false,
   thumbnailUrl,
 }: GameDevProjectCardProps) => {
   return (
@@ -40,6 +44,8 @@ export const GameDevProjectCard = ({
       icon={icon}
       index={index}
       compact={compact}
+      contentSized={contentSized}
+      openOnDoubleClick={openOnDoubleClick}
       thumbnailUrl={thumbnailUrl}
       theme={{
         containerClassName:

--- a/src/components/ui/gamedev/common/cards/GameDevProjectCard.tsx
+++ b/src/components/ui/gamedev/common/cards/GameDevProjectCard.tsx
@@ -34,6 +34,12 @@ export const GameDevProjectCard = ({
   openOnDoubleClick = false,
   thumbnailUrl,
 }: GameDevProjectCardProps) => {
+  const baseContainer =
+    "group flex flex-col rounded-xl border border-white/10 bg-gray-800/90 backdrop-blur-sm";
+  const containerClassName = contentSized
+    ? `${baseContainer} h-auto overflow-visible`
+    : `${baseContainer} h-full overflow-hidden`;
+
   return (
     <ProjectCardBase
       title={title}
@@ -48,8 +54,7 @@ export const GameDevProjectCard = ({
       openOnDoubleClick={openOnDoubleClick}
       thumbnailUrl={thumbnailUrl}
       theme={{
-        containerClassName:
-          "group flex h-full flex-col overflow-hidden rounded-xl border border-white/10 bg-gray-800/90 backdrop-blur-sm",
+        containerClassName,
         iconShellClassName:
           "rounded-lg border border-purple-500/20 bg-purple-500/15 shadow-[inset_0_2px_8px_rgba(0,0,0,0.6)]",
         titleClassName: "font-semibold text-white transition-colors group-hover:text-purple-300",

--- a/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
+++ b/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
@@ -297,7 +297,7 @@ export const GameDevGallery = ({
               {items.map((item, index) => (
                 <div
                   key={item.id}
-                  className="shrink-0 overflow-visible"
+                  className="shrink-0 overflow-hidden"
                   style={{ height: dynamicCardH }}
                 >
                   <GalleryInfoCard

--- a/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
+++ b/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
@@ -31,12 +31,16 @@ const GalleryInfoCard = ({
   iconMap,
   withThumbnail = false,
   compact = false,
+  contentSized = false,
+  openOnDoubleClick = false,
 }: {
   item: GameDevItem;
   index: number;
   iconMap: Record<string, React.ElementType>;
   withThumbnail?: boolean;
   compact?: boolean;
+  contentSized?: boolean;
+  openOnDoubleClick?: boolean;
 }) => {
   const ProjectIcon = (
     item.icon_name ? (iconMap[item.icon_name] ?? Gamepad2) : Gamepad2
@@ -52,6 +56,8 @@ const GalleryInfoCard = ({
       icon={<ProjectIcon className="h-6 w-6 text-purple-300 drop-shadow-[0_0_4px_currentColor]" />}
       index={index}
       compact={compact}
+      contentSized={contentSized}
+      openOnDoubleClick={openOnDoubleClick}
       thumbnailUrl={withThumbnail ? item.thumbnail_url : undefined}
     />
   );
@@ -289,8 +295,19 @@ export const GameDevGallery = ({
               viewportRef={stripRef}
             >
               {items.map((item, index) => (
-                <div key={item.id} className="flex-1 min-h-0 min-h-min">
-                  <GalleryInfoCard item={item} index={index} iconMap={iconMap} compact />
+                <div
+                  key={item.id}
+                  className="shrink-0 overflow-visible"
+                  style={{ height: dynamicCardH }}
+                >
+                  <GalleryInfoCard
+                    item={item}
+                    index={index}
+                    iconMap={iconMap}
+                    compact
+                    contentSized
+                    openOnDoubleClick
+                  />
                 </div>
               ))}
             </VerticalOffsetFrame>
@@ -335,7 +352,7 @@ export const GameDevGallery = ({
   // ── Full gallery — paginated grid of info cards ────────────────────────
 
   const pageItems = items.slice(safePage * ITEMS_PER_PAGE, (safePage + 1) * ITEMS_PER_PAGE);
-  // denseCards → use 2-row grid to fill the full-height panel; cards stay full-size
+  // denseCards → 3-col grid with content-sized rows on desktop
   const useDenseGrid = denseCards && isDesktop;
 
   return (
@@ -345,9 +362,9 @@ export const GameDevGallery = ({
       onTouchEnd={onTouchEnd}
     >
       {isLoading ? (
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 md:grid-cols-3 md:grid-rows-2 md:auto-rows-fr md:gap-4">
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 md:grid-cols-3 md:auto-rows-auto md:items-start md:gap-4">
           {Array.from({ length: ITEMS_PER_PAGE }).map((_, i) => (
-            <div key={i} className="h-40 rounded-xl bg-gray-700/40 animate-pulse md:h-full" />
+            <div key={i} className="h-40 rounded-xl bg-gray-700/40 animate-pulse" />
           ))}
         </div>
       ) : items.length === 0 ? (
@@ -359,10 +376,10 @@ export const GameDevGallery = ({
           <PaginatedSlideFrame
             direction={direction}
             frameKey={frameKey}
-            wrapperClassName="min-h-0 flex-1"
-            clipClassName="relative h-full min-h-0 overflow-hidden"
-            contentClassName={`grid h-full min-h-0 grid-cols-1 gap-3 md:gap-4 ${
-              useDenseGrid ? "md:grid-cols-3 md:grid-rows-2 md:auto-rows-fr" : "md:grid-cols-3"
+            wrapperClassName={useDenseGrid ? "min-h-0 flex-1 overflow-y-auto pr-1" : "min-h-0 flex-1"}
+            clipClassName="relative min-h-0"
+            contentClassName={`grid grid-cols-1 gap-3 md:gap-4 ${
+              useDenseGrid ? "md:grid-cols-3 md:auto-rows-auto md:items-start" : "md:grid-cols-3"
             }`}
           >
             {pageItems.map((item, index) => (
@@ -372,6 +389,8 @@ export const GameDevGallery = ({
                 index={index}
                 iconMap={iconMap}
                 withThumbnail
+                contentSized={useDenseGrid}
+                openOnDoubleClick={isDesktop}
               />
             ))}
 
@@ -385,7 +404,7 @@ export const GameDevGallery = ({
                 return (
                   <div
                     key={`ghost-${i}`}
-                    className="pointer-events-none select-none opacity-0"
+                    className="pointer-events-none invisible select-none h-0 overflow-hidden"
                     aria-hidden="true"
                   >
                     <GalleryInfoCard item={template} index={i} iconMap={iconMap} withThumbnail />

--- a/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
+++ b/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
@@ -376,7 +376,9 @@ export const GameDevGallery = ({
           <PaginatedSlideFrame
             direction={direction}
             frameKey={frameKey}
-            wrapperClassName={useDenseGrid ? "min-h-0 flex-1 overflow-y-auto pr-1" : "min-h-0 flex-1"}
+            wrapperClassName={
+              useDenseGrid ? "min-h-0 flex-1 overflow-y-auto pr-1" : "min-h-0 flex-1"
+            }
             clipClassName="relative min-h-0"
             contentClassName={`grid grid-cols-1 gap-3 md:gap-4 ${
               useDenseGrid ? "md:grid-cols-3 md:auto-rows-auto md:items-start" : "md:grid-cols-3"
@@ -404,7 +406,7 @@ export const GameDevGallery = ({
                 return (
                   <div
                     key={`ghost-${i}`}
-                    className="pointer-events-none invisible select-none h-0 overflow-hidden"
+                    className="pointer-events-none select-none opacity-0"
                     aria-hidden="true"
                   >
                     <GalleryInfoCard item={template} index={i} iconMap={iconMap} withThumbnail />

--- a/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
+++ b/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
@@ -379,7 +379,7 @@ export const GameDevGallery = ({
             wrapperClassName={
               useDenseGrid ? "min-h-0 flex-1 overflow-y-auto pr-1" : "min-h-0 flex-1"
             }
-            clipClassName="relative min-h-0"
+            clipClassName="relative min-h-0 overflow-x-hidden"
             contentClassName={`grid grid-cols-1 gap-3 md:gap-4 ${
               useDenseGrid ? "md:grid-cols-3 md:auto-rows-auto md:items-start" : "md:grid-cols-3"
             }`}

--- a/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
+++ b/src/components/ui/gamedev/common/gallery/GameDevGallery.tsx
@@ -409,7 +409,14 @@ export const GameDevGallery = ({
                     className="pointer-events-none select-none opacity-0"
                     aria-hidden="true"
                   >
-                    <GalleryInfoCard item={template} index={i} iconMap={iconMap} withThumbnail />
+                    <GalleryInfoCard
+                      item={template}
+                      index={i}
+                      iconMap={iconMap}
+                      withThumbnail
+                      contentSized={useDenseGrid}
+                      openOnDoubleClick={isDesktop}
+                    />
                   </div>
                 );
               }}

--- a/src/components/ui/gamedev/mobile/gallery/GameDevHiveGallery.tsx
+++ b/src/components/ui/gamedev/mobile/gallery/GameDevHiveGallery.tsx
@@ -73,7 +73,7 @@ const GRID_CONFIG = {
     cellWidth: 108,
     cellHeight: 112,
     cardWidth: 86,
-    cardHeight: 98,
+    cardHeight: 108,
     centerScale: 1.22,
     ringOneScale: 0.94,
     ringTwoScale: 0.66,
@@ -92,7 +92,7 @@ const GRID_CONFIG = {
     cellWidth: 70,
     cellHeight: 76,
     cardWidth: 58,
-    cardHeight: 68,
+    cardHeight: 76,
     centerScale: 1.14,
     ringOneScale: 0.9,
     ringTwoScale: 0.72,
@@ -684,24 +684,26 @@ export const GameDevHiveGallery = ({
         : null}
 
       <div className="gamedev-hive-meta">
-        <p className="gamedev-hive-caption">
-          {isSpreadMode
-            ? "Release to collapse the spread view."
-            : "Swipe to spin the hive, tap any node to focus it, or hold to spread it."}
-        </p>
-
         <MotionLink
           to={buildGameDevProjectPath(activeItem.id)}
           whileHover={{ scale: 1.04 }}
           whileTap={{ scale: 0.96 }}
           onMouseEnter={playHoverSound}
           onClick={playClickSound}
-          className="inline-flex items-center justify-center rounded-md border border-cyan-400/35 bg-cyan-500/15 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-cyan-100 transition-colors hover:border-cyan-300/60 hover:bg-cyan-400/20"
+          className="gamedev-hive-open-link inline-flex w-full items-center justify-center rounded-md border border-cyan-400/35 bg-cyan-500/15 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-cyan-100 transition-colors hover:border-cyan-300/60 hover:bg-cyan-400/20"
         >
           Open Project Page
         </MotionLink>
 
-        <p className="gamedev-hive-count">{items.length} visible</p>
+        <div className="gamedev-hive-meta-row">
+          <p className="gamedev-hive-caption">
+            {isSpreadMode
+              ? "Release to collapse the spread view."
+              : "Swipe to spin the hive, tap any node to focus it, or hold to spread it."}
+          </p>
+
+          <p className="gamedev-hive-count">{items.length} visible</p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/gamedev/mobile/layouts/GameDevOverviewMobileShort.tsx
+++ b/src/components/ui/gamedev/mobile/layouts/GameDevOverviewMobileShort.tsx
@@ -148,7 +148,7 @@ export const GameDevOverviewMobileShort = ({
               <GameDevPanelShell
                 eyebrow="Featured Gallery"
                 title="Selected Work"
-                className="h-[95%]"
+                className="h-full"
                 clipScroll
                 footer={
                   <GameDevPanelButton

--- a/src/styles/components/gamedev/mobile.css
+++ b/src/styles/components/gamedev/mobile.css
@@ -27,6 +27,10 @@
     @apply h-full;
   }
 
+  .gamedev-mobile-short-panel .gamedev-panel-primary-button {
+    @apply shrink-0;
+  }
+
   /* Short-height phone layout — tab-based so showreel and gallery don't compete */
 
   .gamedev-overview-mobile-short-stack {
@@ -163,7 +167,7 @@
   }
 
   .gamedev-hive-node {
-    @apply absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-start gap-1 rounded-[1rem] border border-white/10 bg-[#09111d]/84 px-1 py-1 text-center text-white shadow-[0_10px_28px_rgba(2,6,23,0.42)] backdrop-blur-sm;
+    @apply absolute flex h-full -translate-x-1/2 -translate-y-1/2 flex-col items-stretch justify-between gap-1 rounded-[1rem] border border-white/10 bg-[#09111d]/84 px-1 py-1 text-center text-white shadow-[0_10px_28px_rgba(2,6,23,0.42)] backdrop-blur-sm;
   }
 
   .gamedev-hive-node--center {
@@ -171,15 +175,15 @@
   }
 
   .gamedev-hive-node-thumb {
-    @apply h-10 w-full rounded-[0.72rem] border border-white/15 bg-cover bg-center shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)];
+    @apply min-h-0 w-full flex-1 rounded-[0.72rem] border border-white/15 bg-cover bg-center shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)];
   }
 
   .gamedev-hive-node-icon {
-    @apply flex h-9 w-full items-center justify-center rounded-[0.72rem] border border-purple-500/30 bg-purple-500/14 text-purple-200;
+    @apply flex min-h-0 w-full flex-1 items-center justify-center rounded-[0.72rem] border border-purple-500/30 bg-purple-500/14 text-purple-200;
   }
 
   .gamedev-hive-node-label {
-    @apply line-clamp-2 w-full px-0.5 text-[8px] font-semibold leading-tight text-gray-200;
+    @apply mt-auto line-clamp-2 w-full shrink-0 px-0.5 text-[8px] font-semibold leading-tight text-gray-200;
   }
 
   .gamedev-hive-focus-core {
@@ -215,7 +219,15 @@
   }
 
   .gamedev-hive-meta {
-    @apply flex items-start justify-between gap-3 px-1;
+    @apply flex shrink-0 flex-col gap-2 px-1 pb-1;
+  }
+
+  .gamedev-hive-meta-row {
+    @apply flex items-start justify-between gap-3;
+  }
+
+  .gamedev-hive-open-link {
+    @apply shrink-0;
   }
 
   .gamedev-hive-caption {


### PR DESCRIPTION
## Summary
- Require double-click to open admin media-library folders and GameDev project cards on desktop (keyboard Enter/Space still opens for accessibility).
- Size desktop Selected Work and All Projects cards to their content so single-item strips and dense grids no longer stretch or clip descriptions.
- Improve mobile hive tiles so thumbnails fill the node, titles sit at the bottom, and the Open Project Page control no longer overlaps the View All Projects footer.

## Test plan
- [ ] Admin → Gallery: single-click folder does not navigate; double-click and Enter/Space open the folder
- [ ] Desktop GameDev → Selected Work with one item: card height matches content, not the full panel
- [ ] Desktop GameDev → All Projects: descriptions are fully visible; cards grow with content
- [ ] Desktop project cards: double-click opens `/gamedev/projects/:id`; GitHub link still works
- [ ] Mobile Selected Work and All Projects: hive thumbnails fill tiles; title at bottom; Open Project Page visible above View All Projects