### PR TITLE
Add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+Project context, conventions, and validate commands live in the `AGENT.md` chain
+(start at the repository-root `AGENT.md`) and `README.md`. Read those first.
+
+## Cursor Cloud specific instructions
+
+This repo is a **frontend-only** React 19 + TypeScript + Vite single-page portfolio.
+There is no backend server to run locally — Supabase (Postgres/Auth) and Cloudflare R2
+are external services and are optional for local development.
+
+- **Run / lint / build / dev commands:** see the `## Validate` block in the root `AGENT.md`
+  (`npm run dev`, `npm run lint`, `npm run build`). Dev server serves on `http://127.0.0.1:5173/`.
+- **Required env to even render (non-obvious):** the SPA reads `VITE_SUPABASE_URL` and
+  `VITE_SUPABASE_ANON_KEY` at startup. Without them the root crashes to a **black screen**
+  (`useAdminIdleLogout` in `src/hooks/auth/useAdminIdleLogout.ts` subscribes to
+  `supabase.auth` synchronously, and the `supabase` proxy throws when unconfigured —
+  despite the "graceful degradation" comment in `src/lib/supabase.ts`). The startup
+  update script seeds a gitignored `.env.local` with **placeholder** values so the public
+  portfolio (Hero / Game Dev / DevOps / About sections, 3D backgrounds, paged scroll
+  navigation) renders. `.env.local` is gitignored (`*.local`) and never committed.
+- **What placeholders do NOT enable:** admin panel (`/admin`), login (`/login`), and any
+  DB-backed content require **real** Supabase credentials (see `.env.example` / `README.md`).
+  With placeholders those areas stay empty or unauthenticated — expected for UI dev.
+- **Edge-function / R2 testing:** the `r2-presign` edge function rejects loopback origins,
+  so upload/edge flows cannot be tested against `npm run dev`; see `README.md` (Environment
+  Variables) for the deployed-preview workflow and `npm run infra:*` / `npm run security:test:*`.
+- **Hero intro lock:** on a first visit the Hero locks scrolling for ~25s for the cinematic
+  intro; a cookie skips it on return visits. Allow for this when scripting navigation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for this frontend-only React 19 + TypeScript + Vite portfolio and documents non-obvious startup caveats for future cloud agents.

- Adds a root `AGENTS.md` with a `## Cursor Cloud specific instructions` section.
- Documents the key gotcha: the SPA requires `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` at startup or the root crashes to a black screen (`useAdminIdleLogout` subscribes to `supabase.auth` synchronously). The startup update script seeds a gitignored placeholder `.env.local` so the public portfolio renders.
- Points to the existing `AGENT.md` `## Validate` block and `README.md` for standard lint/build/dev commands rather than duplicating them.

No application code is modified.

## Environment setup

- Update script: `npm install` + idempotent guarded creation of placeholder `.env.local`.
- Verified `npm run lint`, `npm run build`, and `npm run dev` (serves on `http://127.0.0.1:5173/`).

## Walkthrough

Demonstrated the core interactive functionality (paged section navigation through Hero → Game Dev → DevOps → About/Contact, project-card hover, and Back-To-Top) running against the dev server.

[portfolio_navigation_clean_demo.mp4](https://cursor.com/agents/bc-2f48f634-8f65-41f0-80b8-e29e5856dd08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_navigation_clean_demo.mp4)

[Hero section](https://cursor.com/agents/bc-2f48f634-8f65-41f0-80b8-e29e5856dd08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhero_section.webp)
[Game Dev card hover](https://cursor.com/agents/bc-2f48f634-8f65-41f0-80b8-e29e5856dd08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgamedev_card_hover.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f48f634-8f65-41f0-80b8-e29e5856dd08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f48f634-8f65-41f0-80b8-e29e5856dd08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

